### PR TITLE
docs(tutorial): add articles for creating and testing Apollo Goner co…

### DIFF
--- a/docs/goner-create-example.md
+++ b/docs/goner-create-example.md
@@ -1,0 +1,377 @@
+# 如何给Gone框架编写Goner组件（上）——编写一个Goner对接Apollo配置中心
+
+- [如何给Gone框架编写Goner组件\[上\]——编写一个Goner对接Apollo配置中心](#如何给gone框架编写goner组件上编写一个goner对接apollo配置中心)
+	- [引言](#引言)
+	- [Gone框架与Goner组件简介](#gone框架与goner组件简介)
+	- [Apollo配置中心简介](#apollo配置中心简介)
+	- [编写Apollo Goner组件的核心思路](#编写apollo-goner组件的核心思路)
+	- [核心代码实现与讲解](#核心代码实现与讲解)
+		- [1. Apollo客户端组件实现](#1-apollo客户端组件实现)
+		- [2. 初始化Apollo客户端](#2-初始化apollo客户端)
+		- [3. 配置获取实现](#3-配置获取实现)
+		- [4. 配置值设置工具函数](#4-配置值设置工具函数)
+		- [5. 配置监听和自动更新依赖注入的值](#5-配置监听和自动更新依赖注入的值)
+		- [提供`gone.LoadFunc`函数，方便使用](#提供goneloadfunc函数方便使用)
+	- [使用Apollo Goner组件的示例](#使用apollo-goner组件的示例)
+		- [1. 编写本地配置文件，支持多种配置格式：JSON、YAML、TOML、Properties 等](#1-编写本地配置文件支持多种配置格式jsonyamltomlproperties-等)
+		- [2. 在服务中使用Apollo配置](#2-在服务中使用apollo配置)
+		- [3. 引入Apollo组件](#3-引入apollo组件)
+	- [高级用法](#高级用法)
+		- [1. 监听配置变更](#1-监听配置变更)
+		- [2. 支持多命名空间](#2-支持多命名空间)
+	- [最佳实践](#最佳实践)
+	- [结论](#结论)
+	- [参考资源](#参考资源)
+
+
+## 引言
+
+在微服务架构中，配置中心是一个非常重要的基础设施，它能够集中管理各个服务的配置信息，实现配置的动态更新。Apollo是携程开源的一款优秀的分布式配置中心，本文将详细讲解如何基于Gone框架编写一个Goner组件对接Apollo配置中心，实现配置的统一管理。
+
+## Gone框架与Goner组件简介
+
+Gone是一个基于Go语言的依赖注入框架，而Goner则是基于Gone框架开发的可复用组件。通过编写Goner组件，我们可以将特定功能模块化，便于在不同项目中复用。
+
+## Apollo配置中心简介
+
+Apollo配置中心主要由以下部分组成：
+- 配置管理界面（Portal）：供用户管理配置
+- 配置服务（ConfigService）：提供配置获取接口
+- 客户端SDK：与服务端交互，获取/监听配置变化
+
+## 编写Apollo Goner组件的核心思路
+
+1. 先通过**goner viper**获取本地关于Apollo连接的配置信息
+2. 封装Apollo客户端，提供**配置获取**和**监听能力**
+3. 实现`gone.Configure`接口，将Apollo配置中心的值直接注入到需要的组件中
+4. 实现配置自动更新机制，监控配置变更，并更新对应的变量值
+5. 支持不同类型配置的解析和转换
+
+## 核心代码实现与讲解
+
+### 1. Apollo客户端组件实现
+
+源代码：[apollo/client.go](https://github.com/gone-io/goner/blob/goner-example/apollo/client.go)
+
+```go:https://github.com/gone-io/goner/blob/goner-example/apollo/client.go
+type apolloClient struct {
+	gone.Flag
+	localConfigure gone.Configure
+	apolloClient   agollo.Client
+
+	changeListener *changeListener `gone:"*"`
+	testFlag       gone.TestFlag   `gone:"*" option:"allowNil"`
+	logger         gone.Logger     `gone:"*" option:"lazy"`
+
+	appId                     string //`gone:"config,apollo.appId"`
+	cluster                   string //`gone:"config,apollo.cluster"`
+	ip                        string //`gone:"config,apollo.ip"`
+	namespace                 string //`gone:"config,apollo.namespace"`
+	secret                    string //`gone:"config,apollo.secret"`
+	isBackupConfig            bool   //`gone:"config,apollo.isBackupConfig"`
+	watch                     bool   //`gone:"config,apollo.watch"`
+	useLocalConfIfKeyNotExist bool   //`gone:"config,apollo.useLocalConfIfKeyNotExist"`
+}
+```
+
+`apolloClient`结构体定义了Apollo客户端组件的各个字段：
+- 依赖注入的组件：`changeListener`、`testFlag`、`logger`
+- Apollo配置项：`appId`、`cluster`、`ip`等
+- 控制选项：`watch`（是否监听配置变更）、`useLocalConfIfKeyNotExist`（当配置不存在时是否使用本地配置）
+
+### 2. 初始化Apollo客户端
+
+```go:https://github.com/gone-io/goner/blob/goner-example/apollo/client.go
+func (s *apolloClient) Init() {
+	s.localConfigure = viper.New(s.testFlag)
+
+	m := map[string]*tuple{
+		"apollo.appId":                     {v: &s.appId, defaultVal: ""},
+		"apollo.cluster":                   {v: &s.cluster, defaultVal: "default"},
+		"apollo.ip":                        {v: &s.ip, defaultVal: ""},
+		"apollo.namespace":                 {v: &s.namespace, defaultVal: "application"},
+		"apollo.secret":                    {v: &s.secret, defaultVal: ""},
+		"apollo.isBackupConfig":            {v: &s.isBackupConfig, defaultVal: "true"},
+		"apollo.watch":                     {v: &s.watch, defaultVal: "false"},
+		"apollo.useLocalConfIfKeyNotExist": {v: &s.useLocalConfIfKeyNotExist, defaultVal: "true"},
+	}
+	for k, t := range m {
+		err := s.localConfigure.Get(k, t.v, t.defaultVal)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	c := &config.AppConfig{
+		AppID:          s.appId,
+		Cluster:        s.cluster,
+		IP:             s.ip,
+		NamespaceName:  s.namespace,
+		IsBackupConfig: s.isBackupConfig,
+		Secret:         s.secret,
+	}
+	client, err := agollo.StartWithConfig(func() (*config.AppConfig, error) {
+		return c, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.apolloClient = client
+	if s.watch {
+		client.AddChangeListener(s.changeListener)
+	}
+}
+```
+
+`Init`方法完成了Apollo客户端的初始化工作：
+1. 创建本地配置源（使用viper组件）
+2. 从本地配置中读取Apollo相关配置项
+3. 创建Apollo客户端配置
+4. 启动Apollo客户端
+5. 如果启用了配置监听，则添加变更监听器
+
+### 3. 配置获取实现
+
+```go:https://github.com/gone-io/goner/blob/goner-example/apollo/client.go
+func (s *apolloClient) Get(key string, v any, defaultVal string) error {
+	if s.watch {
+		s.changeListener.Put(key, v)
+	}
+
+	if s.apolloClient == nil {
+		return s.localConfigure.Get(key, v, defaultVal)
+	}
+
+	namespaces := strings.Split(s.namespace, ",")
+	for _, ns := range namespaces {
+		cache := s.apolloClient.GetConfigCache(ns)
+		if cache != nil {
+			if value, err := cache.Get(key); err == nil {
+				err = setValue(v, value)
+				if err != nil {
+					s.warnf("try to set `%s` value err:%v\n", key, err)
+				} else {
+					return nil
+				}
+			} else {
+				s.warnf("get `%s` value from apollo ns(%s) err:%v\n", key, ns, err)
+			}
+		}
+	}
+	if s.useLocalConfIfKeyNotExist {
+		return s.localConfigure.Get(key, v, defaultVal)
+	}
+	return nil
+}
+```
+
+`Get`方法是获取配置的核心实现：
+1. 如果启用了配置监听，则将配置键与变量引用关联起来
+2. 如果Apollo客户端未初始化，则从本地配置获取
+3. 遍历所有命名空间，尝试从Apollo获取配置
+4. 如果获取成功，则将配置值设置到变量中
+5. 如果从Apollo获取失败且允许使用本地配置，则从本地配置获取
+
+### 4. 配置值设置工具函数
+
+```go:https://github.com/gone-io/goner/blob/goner-example/apollo/client.go
+func setValue(v any, value any) error {
+	if str, ok := value.(string); ok {
+		return gone.ToError(gone.SetValue(reflect.ValueOf(v), v, str))
+	} else {
+		marshal, err := json.Marshal(value)
+		if err != nil {
+			return gone.ToError(err)
+		}
+		return gone.ToError(gone.SetValue(reflect.ValueOf(v), v, string(marshal)))
+	}
+}
+```
+
+`setValue`函数用于将配置值设置到变量中：
+1. 如果配置值是字符串，则直接设置
+2. 如果配置值是其他类型，则先转换为JSON字符串，再设置
+
+### 5. 配置监听和自动更新依赖注入的值
+
+```go:https://github.com/gone-io/goner/blob/goner-example/apollo/client.go
+type changeListener struct {
+    gone.Flag
+    keyMap map[string]any
+    logger gone.Logger `gone:"*" option:"lazy"`
+}
+
+func (c *changeListener) Init() {
+    c.keyMap = make(map[string]any)
+}
+
+func (c *changeListener) Put(key string, v any) {
+    c.keyMap[key] = v
+}
+
+func (c *changeListener) OnChange(event *storage.ChangeEvent) {
+    for k, change := range event.Changes {
+        if v, ok := c.keyMap[k]; ok && change.ChangeType == storage.MODIFIED {
+            err := setValue(v, change.NewValue)
+            if err != nil && c.logger != nil {
+                c.logger.Warnf("try to change `%s` value  err: %v\n", k, err)
+            }
+        }
+    }
+}
+
+func (c *changeListener) OnNewestChange(*storage.FullChangeEvent) {}
+```
+
+`changeListener`实现了Apollo客户端的配置变更监听接口：
+- `Init`方法初始化一个map用于存储配置键与对应的变量引用
+- `Put`方法将配置键与变量引用关联起来
+- `OnChange`方法在配置变更时被调用，它会遍历所有变更的配置，找到对应的变量引用，并更新其值
+- `OnNewestChange`方法是接口要求实现的，但在本例中没有具体逻辑
+
+### 提供`gone.LoadFunc`函数，方便使用
+```go:https://github.com/gone-io/goner/blob/goner-example/apollo/client.go
+var load = gone.OnceLoad(func(loader gone.Loader) error {
+    err := loader.
+        Load(
+            &apolloClient{},
+            gone.Name(gone.ConfigureName),
+            gone.IsDefault(new(gone.Configure)),
+            gone.ForceReplace(),
+        )
+    if err != nil {
+        return err
+    }
+    return loader.Load(&changeListener{})
+})
+
+func Load(loader gone.Loader) error {
+    return load(loader)
+}
+```
+
+这段代码使用`gone.OnceLoad`确保组件只被加载一次，并通过`loader.Load`方法注册了两个组件：
+- `apolloClient`：实现了`gone.Configure`接口，用于获取配置
+- `changeListener`：用于监听配置变更
+
+
+## 使用Apollo Goner组件的示例
+
+### 1. 编写本地配置文件，支持多种配置格式：JSON、YAML、TOML、Properties 等
+```yml
+# config/default.yml
+apollo:
+  appId: SampleApp
+  cluster: default
+  ip: http://127.0.0.1:8080
+  namespace: application,test.yml
+  secret: your-secret
+  isBackupConfig: false
+  watch: false
+  useLocalConfIfKeyNotExist: true
+```
+
+
+
+### 2. 在服务中使用Apollo配置
+
+```go
+type MyService struct {
+	gone.Flag
+	
+	// 服务配置
+	serverPort int `gone:"config,server.port"`
+	timeout    int `gone:"config,service.timeout"`
+}
+
+func (s *MyService) Init() {
+	// 使用配置
+	fmt.Printf("服务启动，端口：%d，超时：%d毫秒\n", s.serverPort, s.timeout)
+}
+```
+
+### 3. 引入Apollo组件
+
+```go
+import (
+	"github.com/gone-io/gone/v2"
+	"github.com/gone-io/goner/apollo"
+)
+
+func main() {
+	gone.
+		Loads(
+			apollo.Load,
+			// 其他组件...
+		).
+		Load(&MyService{}).
+		Run(func() {
+			// ...
+        })
+}
+```
+
+## 高级用法
+
+### 1. 监听配置变更
+
+通过启用`apollo.watch`配置，可以实现配置的自动更新：
+
+**注意**： 需要动态更新的字段，**必须使用指针类型**才有效。
+
+```go
+type MyService struct {
+    gone.Flag
+    
+    // 服务配置
+    serverPort *int `gone:"config,server.port"`
+    timeout    *int `gone:"config,service.timeout"`
+}
+
+func (s *MyService) Init() {
+	
+	go func() {
+		for {
+            fmt.Printf("服务启动，端口：%d，超时：%d毫秒\n", *s.serverPort, *s.timeout)
+			time.Sleep(2 * time.Second)
+        }
+    }
+}
+```
+
+### 2. 支持多命名空间
+
+Apollo支持多个命名空间，可以通过逗号分隔的方式在`apollo.namespace`中指定：
+```yml
+# config/default.yml
+
+# 在配置文件中设置
+apollo.namespace: application,test.yml,database
+```
+
+**注意**：不是properties类型的namespace需要带后缀名才能正常的从Apollo上获取到值。
+
+这样，在获取配置时会依次从这些命名空间中查找。
+
+## 最佳实践
+
+1. **配置分层管理**：将配置按照应用、环境、集群等维度进行分层管理
+
+2. **默认值处理**：获取配置时始终提供合理的默认值，避免因配置缺失导致应用崩溃
+
+3. **优雅降级**：当Apollo服务不可用时，应用应能够使用本地缓存的配置继续运行
+
+4. **配置变更验证**：对于关键配置的变更，应进行合理性验证，避免错误配置导致系统问题
+
+5. **监控与告警**：对配置获取失败、配置变更等关键事件进行监控和告警
+
+## 结论
+
+通过本文的讲解，我们了解了如何基于Gone框架编写一个Goner组件对接Apollo配置中心，实现配置的统一管理。这种方式不仅简化了配置管理的复杂度，还提供了配置动态更新的能力，使应用更加灵活和可维护。
+
+在实际项目中，我们可以根据需求对Apollo Goner组件进行扩展，例如添加更多的配置类型支持、增强配置变更的处理逻辑等，以满足不同场景的需求。
+
+## 参考资源
+1. Apollo官方文档：https://www.apolloconfig.com/
+2. Gone框架文档：https://github.com/gone-io/gone
+3. Apollo Go客户端：https://github.com/apolloconfig/agollo

--- a/docs/goner-create-example_en.md
+++ b/docs/goner-create-example_en.md
@@ -1,0 +1,373 @@
+# How to Create a Goner Component for Gone Framework [Part 1] - Integrating with Apollo Configuration Center
+
+- [How to Create a Goner Component for Gone Framework \[Part 1\] - Integrating with Apollo Configuration Center](#how-to-create-a-goner-component-for-gone-framework-part-1---integrating-with-apollo-configuration-center)
+  - [Introduction](#introduction)
+  - [Gone Framework and Goner Component Overview](#gone-framework-and-goner-component-overview)
+  - [Apollo Configuration Center Overview](#apollo-configuration-center-overview)
+  - [Core Approach to Developing Apollo Goner Component](#core-approach-to-developing-apollo-goner-component)
+  - [Core Implementation and Explanation](#core-implementation-and-explanation)
+    - [1. Apollo Client Component Implementation](#1-apollo-client-component-implementation)
+    - [2. Initializing Apollo Client](#2-initializing-apollo-client)
+    - [3. Configuration Retrieval Implementation](#3-configuration-retrieval-implementation)
+    - [4. Configuration Value Setting Utility Function](#4-configuration-value-setting-utility-function)
+    - [5. Configuration Monitoring and Automatic Value Updates](#5-configuration-monitoring-and-automatic-value-updates)
+    - [Providing `gone.LoadFunc` for Easy Use](#providing-goneloadfunc-for-easy-use)
+  - [Example Usage of Apollo Goner Component](#example-usage-of-apollo-goner-component)
+    - [1. Writing Local Configuration Files (Supporting Multiple Formats: JSON, YAML, TOML, Properties, etc.)](#1-writing-local-configuration-files-supporting-multiple-formats-json-yaml-toml-properties-etc)
+    - [2. Using Apollo Configuration in Services](#2-using-apollo-configuration-in-services)
+    - [3. Importing Apollo Component](#3-importing-apollo-component)
+  - [Advanced Usage](#advanced-usage)
+    - [1. Monitoring Configuration Changes](#1-monitoring-configuration-changes)
+    - [2. Supporting Multiple Namespaces](#2-supporting-multiple-namespaces)
+  - [Best Practices](#best-practices)
+  - [Conclusion](#conclusion)
+  - [References](#references)
+
+## Introduction
+
+In microservice architecture, a configuration center is a crucial infrastructure component that centrally manages configuration information for various services and enables dynamic configuration updates. Apollo is an excellent distributed configuration center open-sourced by Ctrip. This article will explain in detail how to create a Goner component based on the Gone framework to integrate with Apollo configuration center, achieving unified configuration management.
+
+## Gone Framework and Goner Component Overview
+
+Gone is a dependency injection framework based on Go language, while Goner is a reusable component developed based on the Gone framework. By creating Goner components, we can modularize specific functionalities for reuse across different projects.
+
+## Apollo Configuration Center Overview
+
+Apollo configuration center consists of the following main parts:
+- Configuration Management Interface (Portal): For user configuration management
+- Configuration Service: Provides configuration retrieval interfaces
+- Client SDK: Interacts with the server to retrieve/monitor configuration changes
+
+## Core Approach to Developing Apollo Goner Component
+
+1. First use **goner viper** to get local Apollo connection configuration information
+2. Encapsulate Apollo client to provide **configuration retrieval** and **monitoring capabilities**
+3. Implement `gone.Configure` interface to directly inject Apollo configuration center values into required components
+4. Implement automatic configuration update mechanism to monitor configuration changes and update corresponding variable values
+5. Support parsing and conversion of different configuration types
+
+## Core Implementation and Explanation
+
+### 1. Apollo Client Component Implementation
+
+Source code: [apollo/client.go](https://github.com/gone-io/goner/blob/goner-example/apollo/client.go)
+
+```go
+type apolloClient struct {
+	gone.Flag
+	localConfigure gone.Configure
+	apolloClient   agollo.Client
+
+	changeListener *changeListener `gone:"*"`
+	testFlag       gone.TestFlag   `gone:"*" option:"allowNil"`
+	logger         gone.Logger     `gone:"*" option:"lazy"`
+
+	appId                     string //`gone:"config,apollo.appId"`
+	cluster                   string //`gone:"config,apollo.cluster"`
+	ip                        string //`gone:"config,apollo.ip"`
+	namespace                 string //`gone:"config,apollo.namespace"`
+	secret                    string //`gone:"config,apollo.secret"`
+	isBackupConfig            bool   //`gone:"config,apollo.isBackupConfig"`
+	watch                     bool   //`gone:"config,apollo.watch"`
+	useLocalConfIfKeyNotExist bool   //`gone:"config,apollo.useLocalConfIfKeyNotExist"`
+}
+```
+
+The `apolloClient` struct defines various fields for the Apollo client component:
+- Dependency-injected components: `changeListener`, `testFlag`, `logger`
+- Apollo configuration items: `appId`, `cluster`, `ip`, etc.
+- Control options: `watch` (whether to monitor configuration changes), `useLocalConfIfKeyNotExist` (whether to use local configuration when configuration doesn't exist)
+
+### 2. Initializing Apollo Client
+
+```go
+func (s *apolloClient) Init() {
+	s.localConfigure = viper.New(s.testFlag)
+
+	m := map[string]*tuple{
+		"apollo.appId":                     {v: &s.appId, defaultVal: ""},
+		"apollo.cluster":                   {v: &s.cluster, defaultVal: "default"},
+		"apollo.ip":                        {v: &s.ip, defaultVal: ""},
+		"apollo.namespace":                 {v: &s.namespace, defaultVal: "application"},
+		"apollo.secret":                    {v: &s.secret, defaultVal: ""},
+		"apollo.isBackupConfig":            {v: &s.isBackupConfig, defaultVal: "true"},
+		"apollo.watch":                     {v: &s.watch, defaultVal: "false"},
+		"apollo.useLocalConfIfKeyNotExist": {v: &s.useLocalConfIfKeyNotExist, defaultVal: "true"},
+	}
+	for k, t := range m {
+		err := s.localConfigure.Get(k, t.v, t.defaultVal)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	c := &config.AppConfig{
+		AppID:          s.appId,
+		Cluster:        s.cluster,
+		IP:             s.ip,
+		NamespaceName:  s.namespace,
+		IsBackupConfig: s.isBackupConfig,
+		Secret:         s.secret,
+	}
+	client, err := agollo.StartWithConfig(func() (*config.AppConfig, error) {
+		return c, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.apolloClient = client
+	if s.watch {
+		client.AddChangeListener(s.changeListener)
+	}
+}
+```
+
+The `Init` method completes Apollo client initialization:
+1. Creates local configuration source (using viper component)
+2. Reads Apollo-related configuration items from local configuration
+3. Creates Apollo client configuration
+4. Starts Apollo client
+5. Adds change listener if configuration monitoring is enabled
+
+### 3. Configuration Retrieval Implementation
+
+```go
+func (s *apolloClient) Get(key string, v any, defaultVal string) error {
+	if s.watch {
+		s.changeListener.Put(key, v)
+	}
+
+	if s.apolloClient == nil {
+		return s.localConfigure.Get(key, v, defaultVal)
+	}
+
+	namespaces := strings.Split(s.namespace, ",")
+	for _, ns := range namespaces {
+		cache := s.apolloClient.GetConfigCache(ns)
+		if cache != nil {
+			if value, err := cache.Get(key); err == nil {
+				err = setValue(v, value)
+				if err != nil {
+					s.warnf("try to set `%s` value err:%v\n", key, err)
+				} else {
+					return nil
+				}
+			} else {
+				s.warnf("get `%s` value from apollo ns(%s) err:%v\n", key, ns, err)
+			}
+		}
+	}
+	if s.useLocalConfIfKeyNotExist {
+		return s.localConfigure.Get(key, v, defaultVal)
+	}
+	return nil
+}
+```
+
+The `Get` method is the core implementation for configuration retrieval:
+1. If configuration monitoring is enabled, associates the configuration key with the variable reference
+2. If Apollo client is not initialized, retrieves from local configuration
+3. Iterates through all namespaces, attempting to retrieve configuration from Apollo
+4. If retrieval is successful, sets the configuration value to the variable
+5. If retrieval from Apollo fails and local configuration use is allowed, retrieves from local configuration
+
+### 4. Configuration Value Setting Utility Function
+
+```go
+func setValue(v any, value any) error {
+	if str, ok := value.(string); ok {
+		return gone.ToError(gone.SetValue(reflect.ValueOf(v), v, str))
+	} else {
+		marshal, err := json.Marshal(value)
+		if err != nil {
+			return gone.ToError(err)
+		}
+		return gone.ToError(gone.SetValue(reflect.ValueOf(v), v, string(marshal)))
+	}
+}
+```
+
+The `setValue` function is used to set configuration values to variables:
+1. If the configuration value is a string, sets it directly
+2. If the configuration value is another type, first converts it to a JSON string, then sets it
+
+### 5. Configuration Monitoring and Automatic Value Updates
+
+```go
+type changeListener struct {
+    gone.Flag
+    keyMap map[string]any
+    logger gone.Logger `gone:"*" option:"lazy"`
+}
+
+func (c *changeListener) Init() {
+    c.keyMap = make(map[string]any)
+}
+
+func (c *changeListener) Put(key string, v any) {
+    c.keyMap[key] = v
+}
+
+func (c *changeListener) OnChange(event *storage.ChangeEvent) {
+    for k, change := range event.Changes {
+        if v, ok := c.keyMap[k]; ok && change.ChangeType == storage.MODIFIED {
+            err := setValue(v, change.NewValue)
+            if err != nil && c.logger != nil {
+                c.logger.Warnf("try to change `%s` value  err: %v\n", k, err)
+            }
+        }
+    }
+}
+
+func (c *changeListener) OnNewestChange(*storage.FullChangeEvent) {}
+```
+
+`changeListener` implements Apollo client's configuration change listening interface:
+- `Init` method initializes a map to store configuration keys and corresponding variable references
+- `Put` method associates configuration keys with variable references
+- `OnChange` method is called when configuration changes, it iterates through all changed configurations, finds corresponding variable references, and updates their values
+- `OnNewestChange` method is required by the interface but has no specific logic in this example
+
+### Providing `gone.LoadFunc` for Easy Use
+```go
+var load = gone.OnceLoad(func(loader gone.Loader) error {
+    err := loader.
+        Load(
+            &apolloClient{},
+            gone.Name(gone.ConfigureName),
+            gone.IsDefault(new(gone.Configure)),
+            gone.ForceReplace(),
+        )
+    if err != nil {
+        return err
+    }
+    return loader.Load(&changeListener{})
+})
+
+func Load(loader gone.Loader) error {
+    return load(loader)
+}
+```
+
+This code uses `gone.OnceLoad` to ensure components are loaded only once, and registers two components through the `loader.Load` method:
+- `apolloClient`: implements the `gone.Configure` interface for configuration retrieval
+- `changeListener`: for monitoring configuration changes
+
+## Example Usage of Apollo Goner Component
+
+### 1. Writing Local Configuration Files (Supporting Multiple Formats: JSON, YAML, TOML, Properties, etc.)
+```yml
+# config/default.yml
+apollo:
+  appId: SampleApp
+  cluster: default
+  ip: http://127.0.0.1:8080
+  namespace: application,test.yml
+  secret: your-secret
+  isBackupConfig: false
+  watch: false
+  useLocalConfIfKeyNotExist: true
+```
+
+### 2. Using Apollo Configuration in Services
+
+```go
+type MyService struct {
+	gone.Flag
+	
+	// Service configuration
+	serverPort int `gone:"config,server.port"`
+	timeout    int `gone:"config,service.timeout"`
+}
+
+func (s *MyService) Init() {
+	// Using configuration
+	fmt.Printf("Service started, port: %d, timeout: %d milliseconds\n", s.serverPort, s.timeout)
+}
+```
+
+### 3. Importing Apollo Component
+
+```go
+import (
+	"github.com/gone-io/gone/v2"
+	"github.com/gone-io/goner/apollo"
+)
+
+func main() {
+	gone.
+		Loads(
+			apollo.Load,
+			// Other components...
+		).
+		Load(&MyService{}).
+		Run(func() {
+			// ...
+        })
+}
+```
+
+## Advanced Usage
+
+### 1. Monitoring Configuration Changes
+
+By enabling `apollo.watch` configuration, automatic configuration updates can be achieved:
+
+**Note**: Fields that need dynamic updates **must use pointer types** to be effective.
+
+```go
+type MyService struct {
+    gone.Flag
+    
+    // Service configuration
+    serverPort *int `gone:"config,server.port"`
+    timeout    *int `gone:"config,service.timeout"`
+}
+
+func (s *MyService) Init() {
+	
+	go func() {
+		for {
+            fmt.Printf("Service running, port: %d, timeout: %d milliseconds\n", *s.serverPort, *s.timeout)
+			time.Sleep(2 * time.Second)
+        }
+    }
+}
+```
+
+### 2. Supporting Multiple Namespaces
+
+Apollo supports multiple namespaces, which can be specified in `apollo.namespace` using comma separation:
+```yml
+# config/default.yml
+
+# In configuration file
+apollo.namespace: application,test.yml,database
+```
+
+**Note**: Non-properties type namespaces need to include the file extension to properly retrieve values from Apollo.
+
+This way, configuration will be searched sequentially in these namespaces.
+
+## Best Practices
+
+1. **Layered Configuration Management**: Manage configurations by dimensions such as application, environment, and cluster
+
+2. **Default Value Handling**: Always provide reasonable default values when retrieving configurations to avoid application crashes due to missing configurations
+
+3. **Graceful Degradation**: Applications should be able to continue running using locally cached configurations when Apollo service is unavailable
+
+4. **Configuration Change Validation**: Validate the rationality of critical configuration changes to avoid system issues caused by incorrect configurations
+
+5. **Monitoring and Alerting**: Monitor and alert on key events such as configuration retrieval failures and configuration changes
+
+## Conclusion
+
+Through this article, we've learned how to create a Goner component based on the Gone framework to integrate with Apollo configuration center, achieving unified configuration management. This approach not only simplifies configuration management complexity but also provides dynamic configuration update capabilities, making applications more flexible and maintainable.
+
+In actual projects, we can extend the Apollo Goner component based on requirements, such as adding support for more configuration types, enhancing configuration change handling logic, etc., to meet the needs of different scenarios.
+
+## References
+1. Apollo Official Documentation: https://www.apolloconfig.com/
+2. Gone Framework Documentation: https://github.com/gone-io/gone
+3. Apollo Go Client: https://github.com/apolloconfig/agollo

--- a/docs/goner-unit-test-example.md
+++ b/docs/goner-unit-test-example.md
@@ -1,0 +1,312 @@
+# 如何给Gone框架编写Goner组件（下）——给对接Apollo的Goner组件编写测试代码
+
+- [如何给Gone框架编写Goner组件（下）——给对接Apollo的Goner组件编写测试代码](#如何给gone框架编写goner组件下给对接apollo的goner组件编写测试代码)
+  - [引言](#引言)
+  - [编写“可测试”的代码](#编写可测试的代码)
+  - [对外部模块进行Mock](#对外部模块进行mock)
+    - [对`gone.Configure`的Mock](#对goneconfigure的mock)
+    - [对`startWithConfig`的Mock](#对startwithconfig的mock)
+  - [编写测试代码](#编写测试代码)
+    - [测试初始化逻辑](#测试初始化逻辑)
+    - [测试配置获取功能](#测试配置获取功能)
+    - [测试配置变更监听功能](#测试配置变更监听功能)
+  - [总结](#总结)
+
+
+> 本文源代码：[https://github.com/gone-io/goner/apollo](https://github.com/gone-io/goner/tree/v0.0.7/apollo)
+
+## 引言
+在上一篇文章[如何给Gone框架编写Goner组件[上]——编写一个Goner对接Apollo配置中心》](./goner-create-example.md)中，我们详细介绍了如何在Gone框架中实现一个Apollo配置中心组件。然而，仅仅实现功能是不够的，为了确保组件的可靠性和稳定性，我们必须为其编写充分的单元测试。本文以Apollo组件为例，深入探讨如何在Gone框架中构建高质量的单元测试，帮助开发者打造更健壮的组件。
+
+## 编写“可测试”的代码
+正如我在另一篇文章[《如何对Golang代码进行单元测试？》](https://blog.csdn.net/waitdeng/article/details/146349708)中提到的，编写单元测试的前提是编写“可测试”的代码，并采用设计可测试代码的实践方法。以以下代码为例，我们需要思考：
+
+- 需要测试哪些部分？
+- 如何对这些部分进行测试？
+
+```go
+func (s *apolloClient) Init() {
+	s.localConfigure = viper.New(s.testFlag)
+
+	m := map[string]*tuple{
+		"apollo.appId":                     {v: &s.appId, defaultVal: ""},
+		"apollo.cluster":                   {v: &s.cluster, defaultVal: "default"},
+		"apollo.ip":                        {v: &s.ip, defaultVal: ""},
+		"apollo.namespace":                 {v: &s.namespace, defaultVal: "application"},
+		"apollo.secret":                    {v: &s.secret, defaultVal: ""},
+		"apollo.isBackupConfig":            {v: &s.isBackupConfig, defaultVal: "true"},
+		"apollo.watch":                     {v: &s.watch, defaultVal: "false"},
+		"apollo.useLocalConfIfKeyNotExist": {v: &s.useLocalConfIfKeyNotExist, defaultVal: "true"},
+	}
+	for k, t := range m {
+		err := s.localConfigure.Get(k, t.v, t.defaultVal)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	c := &config.AppConfig{
+		AppID:          s.appId,
+		Cluster:        s.cluster,
+		IP:             s.ip,
+		NamespaceName:  s.namespace,
+		IsBackupConfig: s.isBackupConfig,
+		Secret:         s.secret,
+	}
+	client, err := agollo.StartWithConfig(func() (*config.AppConfig, error) {
+		return c, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.apolloClient = client
+	if s.watch {
+		client.AddChangeListener(s.changeListener)
+	}
+}
+```
+
+针对上述代码的测试较为困难，主要原因在于它依赖了两个外部系统：`viper` 和 `agollo`。其中，对于`viper`我们可以通过本地配置文件或环境变量来解决，而对于`agollo`则需要搭建一套Apollo服务，这在自动化测试环境中成本较高。  
+因此，我们应关注的是`apolloClient`的初始化逻辑，而不必测试viper的配置读取或agollo的启动。为此，可以将对外部模块的依赖进行外部化，改写后的代码如下：
+
+```go
+func (s *apolloClient) init(localConfigure gone.Configure, startWithConfig func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error)) {
+	type tuple struct {
+		v          any
+		defaultVal string
+	}
+
+	m := map[string]*tuple{
+		"apollo.appId":                     {v: &s.appId, defaultVal: ""},
+		"apollo.cluster":                   {v: &s.cluster, defaultVal: "default"},
+		"apollo.ip":                        {v: &s.ip, defaultVal: ""},
+		"apollo.namespace":                 {v: &s.namespace, defaultVal: "application"},
+		"apollo.secret":                    {v: &s.secret, defaultVal: ""},
+		"apollo.isBackupConfig":            {v: &s.isBackupConfig, defaultVal: "true"},
+		"apollo.watch":                     {v: &s.watch, defaultVal: "false"},
+		"apollo.useLocalConfIfKeyNotExist": {v: &s.useLocalConfIfKeyNotExist, defaultVal: "true"},
+	}
+	for k, t := range m {
+		err := localConfigure.Get(k, t.v, t.defaultVal)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	c := &config.AppConfig{
+		AppID:          s.appId,
+		Cluster:        s.cluster,
+		IP:             s.ip,
+		NamespaceName:  s.namespace,
+		IsBackupConfig: s.isBackupConfig,
+		Secret:         s.secret,
+	}
+	client, err := startWithConfig(func() (*config.AppConfig, error) {
+		return c, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.apolloClient = client
+	if s.watch {
+		client.AddChangeListener(s.changeListener)
+	}
+}
+
+func (s *apolloClient) Init() {
+	s.localConfigure = viper.New(s.testFlag)
+	s.init(s.localConfigure, agollo.StartWithConfig)
+}
+```
+
+通过这种改造，我们可以在测试时只关注`init()`函数的逻辑，而不必依赖实际的外部模块，从而大大降低了测试成本。
+
+## 对外部模块进行Mock
+针对改造后的`init()`函数，其依赖主要集中在两个方面：
+- `localConfigure`（类型为`gone.Configure`）
+- `startWithConfig`函数（签名为`func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error)`）
+
+### 对`gone.Configure`的Mock
+我们可以利用**mockgen**工具直接生成接口的模拟实现，命令如下：
+```bash
+go install go.uber.org/mock/mockgen@latest
+mockgen -package=apollo github.com/gone-io/gone/v2 Configure > gone_mock_test.go
+```
+
+### 对`startWithConfig`的Mock
+首先，利用**mockgen**生成`agollo.Client`接口的模拟实现：
+```bash
+mockgen -package=apollo github.com/apolloconfig/agollo/v4 Client > agollo_mock_test.go
+```
+然后，为测试`startWithConfig`构建一个模拟函数：
+```go
+mockClient := NewMockClient(ctrl)
+mockedStartWithConfig = func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error) {
+	return mockClient, nil
+}
+```
+
+## 编写测试代码
+
+### 测试初始化逻辑
+该测试用例主要验证以下几点：
+1. 配置项是否正确读取
+2. 默认值是否生效
+3. Apollo客户端是否被正确创建
+
+```go
+func TestApolloClient_Init(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// 创建模拟对象
+	localConfigure := NewMockConfigure(ctrl)
+
+	// 设置模拟对象的行为
+	localConfigure.EXPECT().Get("apollo.appId", gomock.Any(), "").Return(nil).Do(
+		func(key string, v any, defaultVal string) {
+			*(v.(*string)) = "testApp"
+		},
+	)
+	// ... 对其他配置项进行相应的Mock设置 ...
+
+	mockClient := NewMockClient(ctrl)
+
+	// 创建apolloClient实例
+	client := &apolloClient{
+		changeListener: &changeListener{},
+	}
+	client.localConfigure = localConfigure
+
+	// 执行初始化
+	client.init(localConfigure, func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error) {
+		return mockClient, nil
+	})
+
+	// 验证配置是否正确读取
+	assert.Equal(t, "testApp", client.appId)
+	assert.Equal(t, "default", client.cluster)
+	// ... 对其他配置项进行验证 ...
+}
+```
+
+### 测试配置获取功能
+此测试用例涵盖了以下场景：
+1. 成功从Apollo获取配置
+2. 当Apollo获取失败时，能够回退到本地配置
+3. 禁用本地配置时的行为
+
+```go
+func TestApolloClient_Get(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// 创建模拟对象
+	localConfigure := NewMockConfigure(ctrl)
+	mockClient := NewMockClient(ctrl)
+	mockCache := NewMockCacheInterface(ctrl)
+
+	// 设置模拟对象的行为
+	mockClient.EXPECT().GetConfigCache("application").Return(mockCache).AnyTimes()
+	mockCache.EXPECT().Get("test.key").Return("test-value", nil).AnyTimes()
+
+	// 创建apolloClient实例
+	client := &apolloClient{
+		localConfigure:            localConfigure,
+		apolloClient:              mockClient,
+		namespace:                 "application",
+		changeListener:            &changeListener{},
+		watch:                     false,
+		useLocalConfIfKeyNotExist: true,
+	}
+
+	// 测试从Apollo获取配置
+	var value string
+	err := client.Get("test.key", &value, "default-value")
+	assert.Nil(t, err)
+	assert.Equal(t, "test-value", value)
+
+	// 测试在Apollo获取失败时使用本地配置
+	mockCache.EXPECT().Get("test.not-exist").Return(nil, errors.New("key not found")).AnyTimes()
+	localConfigure.EXPECT().Get("test.not-exist", gomock.Any(), "default-value").Return(nil).Do(
+		func(key string, v any, defaultVal string) {
+			*(v.(*string)) = "local-value"
+		},
+	)
+
+	var localValue string
+	err = client.Get("test.not-exist", &localValue, "default-value")
+	assert.Nil(t, err)
+	assert.Equal(t, "local-value", localValue)
+}
+```
+
+### 测试配置变更监听功能
+此测试用例主要验证：
+1. 配置监听是否正确注册
+2. 当配置发生变化时，值是否能被正确更新
+
+```go
+func TestApolloClient_Get_WithWatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// 创建并设置必要的模拟对象
+	// ...
+
+	// 创建changeListener并初始化
+	listener := &changeListener{}
+	listener.Init()
+
+	// 创建apolloClient实例，设置watch为true
+	client := &apolloClient{
+		// ...
+		watch: true,
+	}
+
+	// 测试获取配置时，带有监听功能
+	var value string
+	err := client.Get("test.key", &value, "default-value")
+	assert.Nil(t, err)
+	assert.Equal(t, "test-value", value)
+
+	// 验证监听器是否正确注册了该key
+	_, exists := listener.keyMap["test.key"]
+	assert.True(t, exists)
+
+	// 模拟配置变更通知
+	changes := make(map[string]*storage.ConfigChange)
+	changes["test.key"] = &storage.ConfigChange{
+		OldValue:   "test-value",
+		NewValue:   "new-value",
+		ChangeType: storage.MODIFIED,
+	}
+
+	changeEvent := &storage.ChangeEvent{
+		Changes: changes,
+	}
+
+	// 触发配置变更通知
+	listener.OnChange(changeEvent)
+
+	// 验证配置值是否已被更新
+	assert.Equal(t, "new-value", value)
+}
+```
+
+## 总结
+通过上述测试用例，我们实现了对Apollo组件核心功能的全面覆盖，主要体现在以下几点：
+
+1. **依赖注入与接口抽象**  
+   将外部依赖（如viper和agollo）外部化，使代码具备更好的可测试性。
+
+2. **Mock外部模块**  
+   使用mockgen生成模拟对象，避免了在测试环境中对实际Apollo服务的依赖，大大降低了测试成本。
+
+3. **完善的测试场景设计**  
+   覆盖了配置读取、获取和变更监听等关键功能，确保组件在各种场景下均能稳定运行。
+
+4. **提升代码可维护性**  
+   通过单元测试为后续代码维护和重构提供了可靠保障，同时也为其他Gone组件的开发提供了可借鉴的测试方法。
+
+这种测试方法不仅能够确保组件功能的正确性，还能显著提高代码质量和开发效率，是构建健壮系统的重要实践。

--- a/docs/goner-unit-test-example_en.md
+++ b/docs/goner-unit-test-example_en.md
@@ -1,0 +1,311 @@
+# How to Write Unit Tests for Gone Framework's Goner Components [Part 2] - Writing Tests for Apollo Configuration Center Component
+- [How to Write Unit Tests for Gone Framework's Goner Components \[Part 2\] - Writing Tests for Apollo Configuration Center Component](#how-to-write-unit-tests-for-gone-frameworks-goner-components-part-2---writing-tests-for-apollo-configuration-center-component)
+  - [Introduction](#introduction)
+  - [Writing "Testable" Code](#writing-testable-code)
+  - [Mocking External Modules](#mocking-external-modules)
+    - [Mocking `gone.Configure`](#mocking-goneconfigure)
+    - [Mocking `startWithConfig`](#mocking-startwithconfig)
+  - [Writing Test Cases](#writing-test-cases)
+    - [Testing Initialization Logic](#testing-initialization-logic)
+    - [Testing Configuration Retrieval](#testing-configuration-retrieval)
+    - [Testing Configuration Change Listening](#testing-configuration-change-listening)
+  - [Summary](#summary)
+
+
+> Source code: [https://github.com/gone-io/goner/apollo](https://github.com/gone-io/goner/tree/v0.0.7/apollo)
+
+## Introduction
+In our previous article [How to Write Goner Components for Gone Framework [Part 1] - Creating a Goner Component for Apollo Configuration Center](./goner-create-example_en.md), we detailed how to implement an Apollo configuration center component in the Gone framework. However, implementing functionality alone is not enough. To ensure the component's reliability and stability, we must write comprehensive unit tests. Using the Apollo component as an example, this article delves into how to build high-quality unit tests in the Gone framework, helping developers create more robust components.
+
+## Writing "Testable" Code
+As mentioned in my other article [How to Write Unit Tests for Golang Code?](https://blog.csdn.net/waitdeng/article/details/146349708), the prerequisite for writing unit tests is creating "testable" code and adopting practices designed for testability. Looking at the following code example, we need to consider:
+
+- Which parts need to be tested?
+- How can we test these parts?
+
+```go
+func (s *apolloClient) Init() {
+	s.localConfigure = viper.New(s.testFlag)
+
+	m := map[string]*tuple{
+		"apollo.appId":                     {v: &s.appId, defaultVal: ""},
+		"apollo.cluster":                   {v: &s.cluster, defaultVal: "default"},
+		"apollo.ip":                        {v: &s.ip, defaultVal: ""},
+		"apollo.namespace":                 {v: &s.namespace, defaultVal: "application"},
+		"apollo.secret":                    {v: &s.secret, defaultVal: ""},
+		"apollo.isBackupConfig":            {v: &s.isBackupConfig, defaultVal: "true"},
+		"apollo.watch":                     {v: &s.watch, defaultVal: "false"},
+		"apollo.useLocalConfIfKeyNotExist": {v: &s.useLocalConfIfKeyNotExist, defaultVal: "true"},
+	}
+	for k, t := range m {
+		err := s.localConfigure.Get(k, t.v, t.defaultVal)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	c := &config.AppConfig{
+		AppID:          s.appId,
+		Cluster:        s.cluster,
+		IP:             s.ip,
+		NamespaceName:  s.namespace,
+		IsBackupConfig: s.isBackupConfig,
+		Secret:         s.secret,
+	}
+	client, err := agollo.StartWithConfig(func() (*config.AppConfig, error) {
+		return c, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.apolloClient = client
+	if s.watch {
+		client.AddChangeListener(s.changeListener)
+	}
+}
+```
+
+Testing the above code is challenging primarily because it depends on two external systems: `viper` and `agollo`. While we can handle `viper` through local configuration files or environment variables, setting up an Apollo service for `agollo` would be costly in an automated testing environment.  
+Therefore, we should focus on testing the initialization logic of `apolloClient` rather than testing viper's configuration reading or agollo's startup. To achieve this, we can externalize the dependencies on external modules. Here's the refactored code:
+
+```go
+func (s *apolloClient) init(localConfigure gone.Configure, startWithConfig func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error)) {
+	type tuple struct {
+		v          any
+		defaultVal string
+	}
+
+	m := map[string]*tuple{
+		"apollo.appId":                     {v: &s.appId, defaultVal: ""},
+		"apollo.cluster":                   {v: &s.cluster, defaultVal: "default"},
+		"apollo.ip":                        {v: &s.ip, defaultVal: ""},
+		"apollo.namespace":                 {v: &s.namespace, defaultVal: "application"},
+		"apollo.secret":                    {v: &s.secret, defaultVal: ""},
+		"apollo.isBackupConfig":            {v: &s.isBackupConfig, defaultVal: "true"},
+		"apollo.watch":                     {v: &s.watch, defaultVal: "false"},
+		"apollo.useLocalConfIfKeyNotExist": {v: &s.useLocalConfIfKeyNotExist, defaultVal: "true"},
+	}
+	for k, t := range m {
+		err := localConfigure.Get(k, t.v, t.defaultVal)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	c := &config.AppConfig{
+		AppID:          s.appId,
+		Cluster:        s.cluster,
+		IP:             s.ip,
+		NamespaceName:  s.namespace,
+		IsBackupConfig: s.isBackupConfig,
+		Secret:         s.secret,
+	}
+	client, err := startWithConfig(func() (*config.AppConfig, error) {
+		return c, nil
+	})
+	if err != nil {
+		panic(err)
+	}
+	s.apolloClient = client
+	if s.watch {
+		client.AddChangeListener(s.changeListener)
+	}
+}
+
+func (s *apolloClient) Init() {
+	s.localConfigure = viper.New(s.testFlag)
+	s.init(s.localConfigure, agollo.StartWithConfig)
+}
+```
+
+With this refactoring, we can focus on testing the `init()` function's logic without depending on actual external modules, significantly reducing testing costs.
+
+## Mocking External Modules
+For the refactored `init()` function, the dependencies are mainly concentrated in two aspects:
+- `localConfigure` (type `gone.Configure`)
+- `startWithConfig` function (signature `func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error)`)
+
+### Mocking `gone.Configure`
+We can use the **mockgen** tool to directly generate mock implementations of the interface:
+```bash
+go install go.uber.org/mock/mockgen@latest
+mockgen -package=apollo github.com/gone-io/gone/v2 Configure > gone_mock_test.go
+```
+
+### Mocking `startWithConfig`
+First, use **mockgen** to generate mock implementations of the `agollo.Client` interface:
+```bash
+mockgen -package=apollo github.com/apolloconfig/agollo/v4 Client > agollo_mock_test.go
+```
+Then, build a mock function for testing `startWithConfig`:
+```go
+mockClient := NewMockClient(ctrl)
+mockedStartWithConfig = func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error) {
+	return mockClient, nil
+}
+```
+
+## Writing Test Cases
+
+### Testing Initialization Logic
+This test case primarily verifies:
+1. Whether configuration items are correctly read
+2. Whether default values are effective
+3. Whether the Apollo client is correctly created
+
+```go
+func TestApolloClient_Init(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create mock objects
+	localConfigure := NewMockConfigure(ctrl)
+
+	// Set mock object behavior
+	localConfigure.EXPECT().Get("apollo.appId", gomock.Any(), "").Return(nil).Do(
+		func(key string, v any, defaultVal string) {
+			*(v.(*string)) = "testApp"
+		},
+	)
+	// ... Set up mocks for other configuration items ...
+
+	mockClient := NewMockClient(ctrl)
+
+	// Create apolloClient instance
+	client := &apolloClient{
+		changeListener: &changeListener{},
+	}
+	client.localConfigure = localConfigure
+
+	// Execute initialization
+	client.init(localConfigure, func(loadAppConfig func() (*config.AppConfig, error)) (agollo.Client, error) {
+		return mockClient, nil
+	})
+
+	// Verify if configurations are correctly read
+	assert.Equal(t, "testApp", client.appId)
+	assert.Equal(t, "default", client.cluster)
+	// ... Verify other configuration items ...
+}
+```
+
+### Testing Configuration Retrieval
+This test case covers the following scenarios:
+1. Successfully retrieving configuration from Apollo
+2. Falling back to local configuration when Apollo retrieval fails
+3. Behavior when local configuration is disabled
+
+```go
+func TestApolloClient_Get(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create mock objects
+	localConfigure := NewMockConfigure(ctrl)
+	mockClient := NewMockClient(ctrl)
+	mockCache := NewMockCacheInterface(ctrl)
+
+	// Set mock object behavior
+	mockClient.EXPECT().GetConfigCache("application").Return(mockCache).AnyTimes()
+	mockCache.EXPECT().Get("test.key").Return("test-value", nil).AnyTimes()
+
+	// Create apolloClient instance
+	client := &apolloClient{
+		localConfigure:            localConfigure,
+		apolloClient:              mockClient,
+		namespace:                 "application",
+		changeListener:            &changeListener{},
+		watch:                     false,
+		useLocalConfIfKeyNotExist: true,
+	}
+
+	// Test retrieving configuration from Apollo
+	var value string
+	err := client.Get("test.key", &value, "default-value")
+	assert.Nil(t, err)
+	assert.Equal(t, "test-value", value)
+
+	// Test using local configuration when Apollo retrieval fails
+	mockCache.EXPECT().Get("test.not-exist").Return(nil, errors.New("key not found")).AnyTimes()
+	localConfigure.EXPECT().Get("test.not-exist", gomock.Any(), "default-value").Return(nil).Do(
+		func(key string, v any, defaultVal string) {
+			*(v.(*string)) = "local-value"
+		},
+	)
+
+	var localValue string
+	err = client.Get("test.not-exist", &localValue, "default-value")
+	assert.Nil(t, err)
+	assert.Equal(t, "local-value", localValue)
+}
+```
+
+### Testing Configuration Change Listening
+This test case primarily verifies:
+1. Whether configuration listening is correctly registered
+2. Whether values are correctly updated when configuration changes
+
+```go
+func TestApolloClient_Get_WithWatch(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create and set up necessary mock objects
+	// ...
+
+	// Create and initialize changeListener
+	listener := &changeListener{}
+	listener.Init()
+
+	// Create apolloClient instance with watch set to true
+	client := &apolloClient{
+		// ...
+		watch: true,
+	}
+
+	// Test configuration retrieval with listening functionality
+	var value string
+	err := client.Get("test.key", &value, "default-value")
+	assert.Nil(t, err)
+	assert.Equal(t, "test-value", value)
+
+	// Verify if the listener correctly registered the key
+	_, exists := listener.keyMap["test.key"]
+	assert.True(t, exists)
+
+	// Simulate configuration change notification
+	changes := make(map[string]*storage.ConfigChange)
+	changes["test.key"] = &storage.ConfigChange{
+		OldValue:   "test-value",
+		NewValue:   "new-value",
+		ChangeType: storage.MODIFIED,
+	}
+
+	changeEvent := &storage.ChangeEvent{
+		Changes: changes,
+	}
+
+	// Trigger configuration change notification
+	listener.OnChange(changeEvent)
+
+	// Verify if the configuration value has been updated
+	assert.Equal(t, "new-value", value)
+}
+```
+
+## Summary
+Through the above test cases, we have achieved comprehensive coverage of the Apollo component's core functionality, primarily reflected in the following aspects:
+
+1. **Dependency Injection and Interface Abstraction**  
+   Externalizing external dependencies (such as viper and agollo) makes the code more testable.
+
+2. **Mocking External Modules**  
+   Using mockgen to generate mock objects avoids dependency on actual Apollo services in the testing environment, significantly reducing testing costs.
+
+3. **Comprehensive Test Scenario Design**  
+   Covering key functionalities such as configuration reading, retrieval, and change listening ensures the component operates stably in various scenarios.
+
+4. **Improved Code Maintainability**  
+   Unit tests provide reliable guarantees for subsequent code maintenance and refactoring while also offering referenceable testing methods for other Gone components.
+
+This testing methodology not only ensures component functionality correctness but also significantly improves code quality and development efficiency, making it an essential practice in building robust systems.


### PR DESCRIPTION
…mponent

- Add article for creating a Goner component for Apollo Configuration Center
- Add article for writing unit tests for the Apollo Goner component
- Cover topics such as component implementation, configuration retrieval, and change listening
- Include detailed code examples and explanations