### PR TITLE
fix(core): prevent registration of named providers with default type conflicts

### DIFF
--- a/core.go
+++ b/core.go
@@ -210,6 +210,14 @@ func (s *Core) Load(goner Goner, options ...Option) error {
 			s.typeProviderDepMap[provider.Type()] = co
 		}
 	}
+	if provider, ok := co.goner.(NamedProvider); ok {
+		for t := range co.defaultTypeMap {
+			if _, ok := s.typeProviderDepMap[t]; ok {
+				return NewInnerErrorWithParams(LoadedError, "provider for type %s is already registered - cannot use IsDefault option when Loading named provider: %T(name=%s)", GetTypeName(t), provider, provider.GonerName())
+			}
+			s.typeProviderDepMap[t] = co
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
- Add check for existing type providers when loading named providers with default types
- Raise error if a provider for the same type is already registered
- Include tests to verify the new behavior and error handling