### PR TITLE
fix(config): add mutex lock for configure.Get

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package gone
 
-const Version = "v2.0.12"
+const Version = "v2.0.14"


### PR DESCRIPTION
- Add a mutex lock to ensure thread safety when calling configure.Get
- Improve error handling by returning the error directly
- Refactor the code to use a defer statement for unlocking the mutex