### PR TITLE
feat(core): Add MustLoad for gone.Loader; Deprecate OnceLoad for Application.Loads ensured LoadFunc loaded once;

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21", "1.22", "1.23", "1.24"]
+        go-version: ["1.24"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/application.go
+++ b/application.go
@@ -32,13 +32,7 @@ func NewApp(loads ...LoadFunc) *Application {
 	preparer := Application{}
 
 	preparer.init()
-	for _, fn := range loads {
-		err := fn(preparer.loader)
-		if err != nil {
-			panic(err)
-		}
-	}
-	return &preparer
+	return preparer.Loads(loads...)
 }
 
 // Preparer is a type alias for Application, representing the main entry point for application setup and execution.
@@ -90,17 +84,20 @@ func Load(goner Goner, options ...Option) *Application {
 	return Default.Load(goner, options...)
 }
 
-// Loads executes multiple LoadFuncs in sequence to configure the Application
+// Loads executes multiple LoadFuncs in sequence to load goner for Application
 // Parameters:
 //   - loads: Variadic LoadFunc parameters that will be executed in order
 //
-// Each LoadFunc typically loads configurations or components.
+// Each LoadFunc typically loads goner components.
 // If any LoadFunc fails during execution, it will trigger a panic.
 //
 // Returns:
 //   - *Application: Returns the Application instance itself for method chaining
 func (s *Application) Loads(loads ...LoadFunc) *Application {
 	for _, fn := range loads {
+		if s.loader.Loaded(genLoaderKey(fn)) {
+			return s
+		}
 		err := fn(s.loader)
 		if err != nil {
 			panic(err)

--- a/core.go
+++ b/core.go
@@ -221,6 +221,13 @@ func (s *Core) Load(goner Goner, options ...Option) error {
 	return nil
 }
 
+func (s *Core) MustLoad(goner Goner, options ...Option) Loader {
+	if err := s.Load(goner, options...); err != nil {
+		panic(err)
+	}
+	return s
+}
+
 // Check performs dependency validation and determines initialization order:
 // 1. Collects all dependencies between components
 // 2. Validates there are no circular dependencies

--- a/help.go
+++ b/help.go
@@ -184,18 +184,13 @@ func genLoaderKey(fn any) LoaderKey {
 //	wrappedLoad(loader)
 //
 // ```
+// Deprecated: this function is never need any more, because Application.Loads ensure that LoadFunc are only loaded once.
 func OnceLoad(fn LoadFunc) LoadFunc {
-	return func(loader Loader) error {
-		var key = genLoaderKey(fn)
-		if loader.Loaded(key) {
-			return nil
-		}
-		return fn(loader)
-	}
+	return fn
 }
 
 // BuildSingProviderLoadFunc creates a LoadFunc that wraps a FunctionProvider and ensures it's loaded only once per Loader instance.
-// It combines the functionality of OnceLoad and WrapFunctionProvider to create a reusable loader function.
+// It combines the functionality of BuildOnceLoad and WrapFunctionProvider to create a reusable loader function.
 //
 // Parameters:
 //   - fn: The FunctionProvider to be wrapped. This function will be converted to a provider component.
@@ -221,10 +216,10 @@ func OnceLoad(fn LoadFunc) LoadFunc {
 //
 // ```
 func BuildSingProviderLoadFunc[P, T any](fn FunctionProvider[P, T], options ...Option) LoadFunc {
-	return OnceLoad(func(loader Loader) error {
+	return func(loader Loader) error {
 		provider := WrapFunctionProvider(fn)
 		return loader.Load(provider, options...)
-	})
+	}
 }
 
 // BuildThirdComponentLoadFunc creates a LoadFunc that registers an existing component into the container.

--- a/help_test.go
+++ b/help_test.go
@@ -2,6 +2,7 @@ package gone
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -475,6 +476,7 @@ func TestGetInterfaceType(t *testing.T) {
 
 // Mock Loader for testing OnceLoad
 type mockLoader struct {
+	Loader
 	loadedKeys map[LoaderKey]bool
 }
 
@@ -510,7 +512,7 @@ func TestLoadFunc(t *testing.T) {
 			return loader.Load(&goner)
 		}
 
-		loadFunc := OnceLoad(originLoader)
+		loadFunc := originLoader
 
 		NewApp(loadFunc, loadFunc).
 			Run(func(goners []*TestGoner) {
@@ -567,6 +569,23 @@ func TestBuildThirdComponentLoadFunc(t *testing.T) {
 				t.Errorf("Expected 1 goner, got %d", len(goners))
 			}
 		})
+}
+
+func TestX(t *testing.T) {
+	type TestComponent struct {
+		i int
+	}
+	type TestComponent2 struct {
+		i int
+	}
+	loadFunc1 := BuildThirdComponentLoadFunc[*TestComponent](&TestComponent{i: 10})
+	loadFunc2 := BuildThirdComponentLoadFunc[*TestComponent2](&TestComponent2{i: 20})
+
+	key1 := fmt.Sprintf("loadFunc1=> %#v\n", loadFunc1)
+	key2 := fmt.Sprintf("loadFunc2=> %#v\n", loadFunc2)
+	if key1 == key2 {
+		t.Errorf("loadFunc1 should not equal to loadFunc2")
+	}
 }
 
 func TestIsError(t *testing.T) {

--- a/interafce.go
+++ b/interafce.go
@@ -580,7 +580,9 @@ type LoaderKey struct{ id uint64 }
 //	}
 //
 // ```
-type LoadFunc func(Loader) error
+type LoadFunc = func(Loader) error
+
+type MustLoadFunc = func(Loader)
 
 // Loader defines the interface for loading components into the Gone container.
 // It provides methods to load new components and check if components are already loaded.
@@ -598,6 +600,17 @@ type Loader interface {
 	// Returns:
 	//   - error: Any error that occurred during loading
 	Load(goner Goner, options ...Option) error
+
+	// MustLoad adds a component to the Gone container with optional configuration.
+	// If an error occurs during loading, it panics.
+	//
+	// Parameters:
+	//   - goner: The component to load. Must implement Goner interface.
+	//   - options: Optional configuration for how the component should be loaded.
+	//
+	// Returns:
+	//   - Loader: The Loader instance for further loading operations
+	MustLoad(goner Goner, options ...Option) Loader
 
 	// Loaded checks if a component identified by the given LoaderKey has been loaded.
 	//

--- a/mock/v2/mock.go
+++ b/mock/v2/mock.go
@@ -682,6 +682,25 @@ func (mr *MockLoaderMockRecorder) Loaded(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Loaded", reflect.TypeOf((*MockLoader)(nil).Loaded), arg0)
 }
 
+// MustLoad mocks base method.
+func (m *MockLoader) MustLoad(goner gone.Goner, options ...gone.Option) gone.Loader {
+	m.ctrl.T.Helper()
+	varargs := []any{goner}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MustLoad", varargs...)
+	ret0, _ := ret[0].(gone.Loader)
+	return ret0
+}
+
+// MustLoad indicates an expected call of MustLoad.
+func (mr *MockLoaderMockRecorder) MustLoad(goner any, options ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{goner}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MustLoad", reflect.TypeOf((*MockLoader)(nil).MustLoad), varargs...)
+}
+
 // MockGonerKeeper is a mock of GonerKeeper interface.
 type MockGonerKeeper struct {
 	ctrl     *gomock.Controller

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package gone
 
-const Version = "v2.0.14"
+const Version = "v2.1.0"


### PR DESCRIPTION

- Add MustLoad method to Core and Loader interfaces
- Implement MustLoad for Core and MockLoader
- Update Application to use MustLoad in Loads method
- Add tests for new MustLoad functionality
- Deprecate OnceLoad function