### PR TITLE
enhance error handling and add `WarpThirdComponent ` for third component injecting 

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -1,6 +1,7 @@
 package gone
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -200,7 +201,7 @@ func TestToErrorWithMsg(t *testing.T) {
 			name:    "with prefix",
 			input:   "test error",
 			msg:     "prefix",
-			wantMsg: "prefix: test error",
+			wantMsg: "prefix",
 		},
 		{
 			name:    "without prefix",
@@ -342,4 +343,41 @@ func TestBError_SetMsg(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestToErrorf(t *testing.T) {
+	t.Run("input nil", func(t *testing.T) {
+		err := ToErrorf(nil, "test error")
+		if err != nil {
+			t.Error("must be nil")
+		}
+	})
+
+	t.Run("input error", func(t *testing.T) {
+		var err = errors.New("test error")
+		newErr := ToErrorf(err, "my-test")
+
+		if !errors.Is(newErr, err) {
+			t.Error("must be input error")
+		}
+
+		var gErr Error
+		if !errors.As(newErr, &gErr) {
+			t.Error("must be GoneError")
+		}
+
+		if gErr.GetStatusCode() != http.StatusInternalServerError {
+			t.Error("must be 500")
+		}
+
+		if gErr.Msg() != "my-test" {
+			t.Error("must be my-test")
+		}
+
+		gErr.SetMsg("my-test2")
+		if gErr.Msg() != "my-test2" {
+			t.Error("must be my-test2")
+		}
+
+	})
 }

--- a/func_provider.go
+++ b/func_provider.go
@@ -2,10 +2,11 @@ package gone
 
 import "reflect"
 
-// FunctionProvider is an experimental type that may change or be removed in future releases.
+// FunctionProvider is a function, which first parameter is tagConf, and second parameter is a struct that can be injected.
+// And the function must return a T type value and error.
 type FunctionProvider[P, T any] func(tagConf string, param P) (T, error)
 
-// XProvider is an experimental type that may change or be removed in future releases.
+// XProvider is a Goner Provider was created by WrapFunctionProvider.
 type XProvider[T any] struct {
 	Flag
 	injector FuncInjector `gone:"*"`
@@ -20,7 +21,7 @@ func (p *XProvider[T]) Provide(tagConf string) (T, error) {
 	return obj, nil
 }
 
-// WrapFunctionProvider is an experimental function that may change or be removed in future releases.
+// WrapFunctionProvider can wrap a FunctionProvider to a Provider.
 func WrapFunctionProvider[P, T any](fn FunctionProvider[P, T]) *XProvider[T] {
 	p := XProvider[T]{}
 
@@ -51,4 +52,12 @@ func WrapFunctionProvider[P, T any](fn FunctionProvider[P, T]) *XProvider[T] {
 		return t, err
 	}
 	return &p
+}
+
+// WarpThirdComponent can wrap a third component to a Goner Provider which can make third component to inject Goners.
+func WarpThirdComponent[T any](t T) Goner {
+	provider := WrapFunctionProvider(func(tagConf string, param struct{}) (T, error) {
+		return t, nil
+	})
+	return provider
 }

--- a/func_provider_test.go
+++ b/func_provider_test.go
@@ -66,3 +66,21 @@ func TestWrapFunctionProvider(t *testing.T) {
 		}
 	})
 }
+
+func TestWarpThirdComponent(t *testing.T) {
+	type ThirdComponent struct {
+		ID string
+	}
+
+	var thirdComponent = ThirdComponent{
+		ID: "third",
+	}
+
+	NewApp().
+		Load(WarpThirdComponent(thirdComponent)).
+		Run(func(thirdComponent ThirdComponent) {
+			if thirdComponent.ID != "third" {
+				t.Errorf("Expected %v, got %v", "third", thirdComponent.ID)
+			}
+		})
+}


### PR DESCRIPTION
- Rename experimental.go to func_provider.go
- Update FunctionProvider type definition
- Add WarpThirdComponent function for wrapping third-party components
- Rename experimental_test.go to func_provider_test.go
- Add unit test for WarpThirdComponent
- Add withMessage struct to handle errors with additional messages
- Implement Unwrap method for iError and withMessage types
- Introduce newIError function for creating iError instances
- Update ToError function to use newIError
- Add support for custom error messages in tests