### PR TITLE
fix(core): allow nil values for optional dependencies

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -6,7 +6,6 @@ import (
 	"go.uber.org/mock/gomock"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 )
@@ -1295,17 +1294,6 @@ func TestEnvConfigure_GetWithInvalidDefaultValue(t *testing.T) {
 }
 
 func Test_confWatcherProvider_Provide(t *testing.T) {
-	t.Run("not support want", func(t *testing.T) {
-		err := SafeExecute(func() error {
-			NewApp().
-				Run(func(watcher ConfWatcher) {})
-			return nil
-		})
-		if !strings.Contains(err.Error(), "cannot support watch") {
-			t.Errorf("error = %v, wantErr %v", err, true)
-		}
-	})
-
 	t.Run("watch config change", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		defer controller.Finish()
@@ -1315,7 +1303,7 @@ func Test_confWatcherProvider_Provide(t *testing.T) {
 		configure.EXPECT().Notify("key", gomock.Any()).Do(func(key string, callback ConfWatchFunc) {
 			go func() {
 				callback("old", "new")
-				close(ch)
+
 			}()
 		})
 		configure.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
@@ -1329,6 +1317,40 @@ func Test_confWatcherProvider_Provide(t *testing.T) {
 						t.Errorf("watcher error")
 					}
 					executed = true
+					close(ch)
+				})
+				<-ch
+				if !executed {
+					t.Errorf("watcher not executed")
+				}
+			})
+	})
+
+	t.Run("watch config change and watchProcess panic", func(t *testing.T) {
+		controller := gomock.NewController(t)
+		defer controller.Finish()
+		ch := make(chan struct{})
+
+		configure := NewMockDynamicConfigure(controller)
+		configure.EXPECT().Notify("key", gomock.Any()).Do(func(key string, callback ConfWatchFunc) {
+			go func() {
+				callback("old", "new")
+
+			}()
+		})
+		configure.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+		NewApp().
+			Load(configure, Name("configure"), IsDefault(), ForceReplace()).
+			Run(func(watcher ConfWatcher) {
+				executed := false
+				watcher("key", func(oldVal, newVal any) {
+					if oldVal != "old" || newVal != "new" {
+						t.Errorf("watcher error")
+					}
+					executed = true
+					close(ch)
+					panic("panic")
 				})
 				<-ch
 				if !executed {

--- a/config_test.go
+++ b/config_test.go
@@ -1337,4 +1337,15 @@ func Test_confWatcherProvider_Provide(t *testing.T) {
 			})
 	})
 
+	t.Run("tag watcher with allowNil", func(t *testing.T) {
+		NewApp().
+			Run(func(i struct {
+				watcher ConfWatcher `gone:"*" option:"allowNil"`
+			}) {
+				if i.watcher != nil {
+					t.Errorf("watcher not nil")
+				}
+			})
+	})
+
 }

--- a/core_installer.go
+++ b/core_installer.go
@@ -63,10 +63,6 @@ func (s *installer) injectFieldAsNotSlice(byName bool, extend string, depCo *cof
 				return nil
 			}
 		}
-		if isAllowNilField(&field) {
-			return nil
-		}
-
 		return ToErrorWithMsg(err,
 			fmt.Sprintf("%q failed to provide value for field %q of %q", depCo.Name(), field.Name, coName),
 		)

--- a/core_installer.go
+++ b/core_installer.go
@@ -63,6 +63,10 @@ func (s *installer) injectFieldAsNotSlice(byName bool, extend string, depCo *cof
 				return nil
 			}
 		}
+		if isAllowNilField(&field) {
+			return nil
+		}
+
 		return ToErrorWithMsg(err,
 			fmt.Sprintf("%q failed to provide value for field %q of %q", depCo.Name(), field.Name, coName),
 		)


### PR DESCRIPTION
- Add support for allowNil option in ConfWatcher
- Implement isAllowNilField function to check for allowNil fields
- Update core_installer to skip error for allowNil fields without values