### PR TITLE
refactor(lifecycle): improve component lifecycle documentation and sorting

### DIFF
--- a/application.go
+++ b/application.go
@@ -6,6 +6,27 @@ import (
 	"syscall"
 )
 
+// Application represents the core container and orchestrator for the Gone framework.
+// Think of it as the "command center" or "central dispatch" of your application - it's like
+// the conductor of an orchestra who knows every musician (component), their instruments (capabilities),
+// and how they should work together to create beautiful music (your application).
+//
+// The Application acts as the central hub that:
+// - Loads and manages all components (like a "personnel manager")
+// - Handles dependency injection between components (like a "matchmaker")
+// - Manages application lifecycle with hooks (like a "stage director")
+// - Provides access to components via the GonerKeeper interface (like a "directory service")
+//
+// Design Philosophy:
+// - Single Responsibility: Each Application instance manages one complete application context
+// - Composition over Inheritance: Built by composing various specialized components
+// - Encapsulation: Internal complexity is hidden behind simple, intuitive interfaces
+//
+// Key responsibilities:
+// - Component registration and loading ("hiring and onboarding")
+// - Dependency resolution and injection ("team building and collaboration")
+// - Lifecycle management with hooks ("project management")
+// - Graceful shutdown handling ("orderly dismissal")
 type Application struct {
 	Flag
 
@@ -21,6 +42,15 @@ type Application struct {
 }
 
 // NewApp creates and initializes a new Application instance.
+// Think of it as "founding a new company" where LoadFuncs are like "department setup plans"
+// that define how to establish different parts of your application. Each LoadFunc knows
+// how to "hire" and "organize" specific types of components.
+//
+// The Creation Process:
+// - Establishes the "company headquarters" (Application instance)
+// - Registers "department setup plans" (LoadFuncs)
+// - Prepares the "organizational structure" for component management
+//
 // It creates an empty Application struct and calls init() to:
 // 1. Initialize signal channel
 // 2. Create new Core
@@ -55,11 +85,19 @@ func (s *Application) init() *Application {
 }
 
 // Load loads a Goner into the Application's loader with optional configuration options.
+// Think of it as "hiring a new employee" where you bring a specific person (component)
+// into your company (application) and give them their "employee handbook" (options).
 // It wraps the Core.Load() method and panics if loading fails.
 //
+// The Hiring Process:
+// - Verify the candidate has proper "credentials" (implements Goner interface)
+// - Assign them a unique "employee ID" (internal tracking)
+// - Set up their "workspace" and "job description" (configuration)
+// - Add them to the "company directory" (component registry)
+//
 // Parameters:
-//   - goner: The Goner instance to load
-//   - options: Optional configuration options for the Goner
+//   - goner: The Goner instance to load - the "new hire"
+//   - options: Optional configuration options for the Goner - the "employment terms"
 //
 // Available Options:
 //   - Name(name string): Set custom name for the Goner
@@ -79,8 +117,16 @@ func (s *Application) Load(goner Goner, options ...Option) *Application {
 }
 
 // Loads executes multiple LoadFuncs in sequence to load goner for Application
+// Think of it as "batch hiring" where you bring multiple new employees into your
+// company at once, like during a "recruitment drive" or "team expansion".
+//
+// The Batch Hiring Process:
+// - Process each LoadFunc in sequence
+// - Each LoadFunc acts like a "department setup plan"
+// - Stop the process if any "hiring" fails
+//
 // Parameters:
-//   - loads: Variadic LoadFunc parameters that will be executed in order
+//   - loads: Variadic LoadFunc parameters that will be executed in order - the "batch of hiring plans"
 //
 // Each LoadFunc typically loads goner components.
 // If any LoadFunc fails during execution, it will trigger a panic.
@@ -95,7 +141,16 @@ func (s *Application) Loads(loads ...LoadFunc) *Application {
 }
 
 // BeforeStart registers a function to be called before starting the application.
-// The function will be executed before any daemons are started.
+// Think of it as scheduling a "pre-opening meeting" where you can perform final preparations
+// before your "business" officially opens its doors. The function will be executed before
+// any daemons are started.
+//
+// Typical Use Cases:
+// - Final system checks and validations
+// - Cache warming and data preloading
+// - External service connections
+// - Configuration validation
+//
 // Returns the Application instance for method chaining.
 func (s *Application) BeforeStart(fn Process) *Application {
 	s.beforeStart(fn)
@@ -107,7 +162,16 @@ func (s *Application) beforeStart(fn Process) {
 }
 
 // AfterStart registers a function to be called after starting the application.
-// The function will be executed after all daemons have been started.
+// Think of it as scheduling a "grand opening celebration" or "post-launch activities"
+// that happen after your "business" is officially open and running. The function will
+// be executed after all daemons have been started.
+//
+// Typical Use Cases:
+// - Success notifications and logging
+// - Health check registrations
+// - Monitoring and metrics setup
+// - External service announcements
+//
 // Returns the Application instance for method chaining.
 func (s *Application) AfterStart(fn Process) *Application {
 	s.afterStart(fn)
@@ -119,7 +183,16 @@ func (s *Application) afterStart(fn Process) {
 }
 
 // BeforeStop registers a function to be called before stopping the application.
-// The function will be executed before any daemons are stopped.
+// Think of it as scheduling "closing preparations" where you perform necessary tasks
+// before your "business" officially closes. The function will be executed before
+// any daemons are stopped.
+//
+// Typical Use Cases:
+// - Graceful connection closures
+// - Data persistence and state saving
+// - Resource cleanup and release
+// - Shutdown notifications
+//
 // Returns the Application instance for method chaining.
 func (s *Application) BeforeStop(fn Process) *Application {
 	s.beforeStop(fn)
@@ -131,7 +204,16 @@ func (s *Application) beforeStop(fn Process) {
 }
 
 // AfterStop registers a function to be called after stopping the application.
-// The function will be executed after all daemons have been stopped.
+// Think of it as "post-closure activities" that happen after your "business" has
+// officially closed its doors. The function will be executed after all daemons
+// have been stopped.
+//
+// Typical Use Cases:
+// - Final cleanup and resource release
+// - Shutdown success logging
+// - External service deregistration
+// - Final state persistence
+//
 // Returns the Application instance for method chaining.
 func (s *Application) AfterStop(fn Process) *Application {
 	s.afterStop(fn)
@@ -143,6 +225,15 @@ func (s *Application) afterStop(fn Process) {
 }
 
 // WaitEnd blocks until the application receives a termination signal (SIGINT, SIGTERM, or SIGQUIT).
+// Think of it as a "security guard" who watches the door and waits for the "closing time signal".
+// This method listens for termination signals (like Ctrl+C or system shutdown) and returns when
+// one is received, allowing for graceful shutdown procedures.
+//
+// Signal Monitoring:
+// - SIGINT: Usually triggered by Ctrl+C ("manual closing")
+// - SIGTERM: System shutdown or process termination ("scheduled closing")
+// - SIGQUIT: Quit signal ("emergency closing")
+//
 // Returns the Application instance for method chaining.
 func (s *Application) WaitEnd() *Application {
 	signal.Notify(s.signal, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
@@ -151,6 +242,10 @@ func (s *Application) WaitEnd() *Application {
 }
 
 // End triggers application termination by sending a SIGINT signal.
+// Think of it as the "official closing procedure" where you send the "closing signal"
+// to initiate graceful shutdown. This method triggers application termination by
+// sending a SIGINT signal.
+//
 // Returns the Application instance for method chaining.
 func (s *Application) End() *Application {
 	s.signal <- syscall.SIGINT
@@ -212,12 +307,12 @@ func (s *Application) collectHooks() {
 					afterStart.AfterStart()
 				})
 			}
-			if stop, ok := co.goner.(BeforeStoper); ok {
+			if stop, ok := co.goner.(BeforeStopper); ok {
 				s.beforeStop(func() {
 					stop.BeforeStop()
 				})
 			}
-			if afterStop, ok := co.goner.(AfterStoper); ok {
+			if afterStop, ok := co.goner.(AfterStopper); ok {
 				s.afterStop(func() {
 					afterStop.AfterStop()
 				})
@@ -228,11 +323,20 @@ func (s *Application) collectHooks() {
 
 // Run initializes the application, injects dependencies into the provided function,
 // executes it, and then performs cleanup.
+// Think of it as "opening your business for a specific task" - you unlock the doors,
+// turn on all systems, perform the specific work, then properly close everything down.
 // The function can have dependencies that will be automatically injected.
 // Panics if dependency injection or execution fails.
 //
+// The Complete Business Day Process:
+// 1. "System setup" - Install and initialize all components
+// 2. "Team coordination" - Collect and register lifecycle hooks
+// 3. "Open for business" - Execute start procedures
+// 4. "Main work" - Execute provided functions with dependency injection
+// 5. "Proper closure" - Execute stop procedures
+//
 // Parameters:
-//   - funcList: The function to execute with injected dependencies
+//   - funcList: The function to execute with injected dependencies - the "main business tasks"
 func (s *Application) Run(funcList ...any) {
 	s.install()
 	s.collectHooks()
@@ -260,7 +364,14 @@ func (s *Application) Run(funcList ...any) {
 }
 
 // Serve initializes the application, starts all daemons, and waits for termination signal.
+// Think of it as "opening your business for continuous operation" - you unlock the doors,
+// start all services, and keep the business running until you receive a "closing signal".
 // After receiving termination signal, performs cleanup by stopping all daemons.
+//
+// The Continuous Operation Process:
+// - Same as Run() but includes OpWaitEnd() to wait for termination signals
+// - Ideal for long-running applications like web servers or background services
+//
 func (s *Application) Serve(funcList ...any) {
 	funcList = append(funcList, OpWaitEnd())
 	s.Run(funcList...)
@@ -290,6 +401,20 @@ type testFlag struct {
 
 func (*testFlag) forTest() {}
 
+// Test runs the application in test mode with dependency injection.
+// Think of it as setting up a "testing laboratory" where you can experiment with your
+// components in a controlled environment. This method is designed for testing scenarios
+// where you need to execute test functions with proper dependency injection.
+//
+// The Testing Laboratory Process:
+// - Loads a test flag to indicate test mode
+// - Executes the test function using Run() with full dependency injection
+//
+// Key Features:
+// - Full dependency injection support
+// - Simplified execution for testing purposes
+// - Test mode indication via testFlag
+//
 func (s *Application) Test(fn any) {
 	s.Load(&testFlag{})
 	s.Run(fn)

--- a/core_keeper.go
+++ b/core_keeper.go
@@ -35,6 +35,8 @@ func (s *keeper) getByTypeAndPattern(t reflect.Type, pattern string) (coffins []
 			coffins = append(coffins, co)
 		}
 	}
+
+	SortCoffins(coffins)
 	return coffins
 }
 

--- a/interface.go
+++ b/interface.go
@@ -6,15 +6,24 @@ import (
 )
 
 // Goner is the base interface that all components managed by Gone must implement.
-// It acts as a marker interface to identify types that can be loaded into the Gone container.
+// It acts as a "component identity card" - any component wanting to be managed by the Gone framework
+// must hold this "identity card". This is a clever design using a private method to ensure
+// only "official channels" can obtain this "identity card".
 //
 // Any struct that embeds the Flag struct automatically implements this interface.
 // This allows Gone to verify that components are properly configured for dependency injection.
+// Just like getting an ID card requires going to the designated office, becoming a Goner
+// can only be achieved by embedding the `gone.Flag` "official seal".
+//
+// Design Benefits:
+//   - Security: Prevents "counterfeit" components from entering the system
+//   - Consistency: Ensures all components follow the same "registration" process
+//   - Control: Framework has complete control over component lifecycle
 //
 // Example usage:
 //
 //	type MyComponent struct {
-//	    gone.Flag  // Embeds Flag to implement Goner
+//	    gone.Flag  // Embeds Flag to implement Goner - the "identity card"
 //	}
 type Goner interface {
 	goneFlag()
@@ -24,13 +33,15 @@ type Goner interface {
 type Component = Goner
 
 // NamedGoner extends the Goner interface to add naming capability to components.
-// Components implementing this interface can be registered and looked up by name in the Gone container.
+// Components implementing this interface can be registered and looked up by name in the Gone container,
+// like having a "business card" with a specific name that others can use to find them.
 //
-// The Name() method should return a unique string identifier for the component.
-// This name can be used when:
+// The GonerName() method should return a unique string identifier for the component.
+// This name acts as the component's "business card" and can be used when:
 // - Loading the component with explicit name
 // - Looking up dependencies by name using `gone:"name"` tags
 // - Registering multiple implementations of the same interface
+// - Distinguishing between different instances of the same type
 //
 // Example usage:
 //
@@ -39,7 +50,7 @@ type Component = Goner
 //	}
 //
 //	func (c *MyNamedComponent) GonerName() string {
-//	    return "myComponent"
+//	    return "myComponent"  // This component's "business card"
 //	}
 type NamedGoner interface {
 	Goner
@@ -47,6 +58,7 @@ type NamedGoner interface {
 }
 
 // Provider is a generic interface for components that can provide dependencies of type T.
+// Think of it as a "smart factory" that can create specific types of components on demand.
 // While not directly dependent on Gone's implementation, this interface helps developers
 // write correct dependency providers that can be registered in the Gone container.
 //
@@ -57,8 +69,12 @@ type NamedGoner interface {
 //   - Embedding the Goner interface to mark it as a Gone component
 //   - Implementing Provide() to create and return instances of type T
 //
+// The Provider acts like a "specialized craftsman" who knows how to create specific types
+// of components based on the requirements (tagConf) provided.
+//
 // Parameters for Provide:
-//   - tagConf: Configuration string from the struct tag that requested this dependency
+//   - tagConf: Configuration string from the struct tag that requested this dependency,
+//             like a "work order" specifying what kind of component is needed
 //
 // Returns:
 //   - T: The created dependency instance
@@ -71,7 +87,7 @@ type NamedGoner interface {
 //	}
 //
 //	func (p *ConfigProvider) Provide(tagConf string) (*Config, error) {
-//	    return &Config{}, nil
+//	    return &Config{}, nil  // Creates a new Config based on requirements
 //	}
 type Provider[T any] interface {
 	Goner
@@ -79,6 +95,7 @@ type Provider[T any] interface {
 }
 
 // NoneParamProvider is a simplified Provider interface for components that provide dependencies without requiring tag configuration.
+// Think of it as a "simple factory" that creates standard products without needing special instructions.
 // Like Provider[T], this interface is not directly dependent on Gone's implementation but serves as a guide
 // for writing simpler providers when tag configuration is not needed.
 //
@@ -88,6 +105,9 @@ type Provider[T any] interface {
 // The interface requires:
 //   - Embedding the Goner interface to mark it as a Gone component
 //   - Implementing Provide() to create and return instances of type T
+//
+// This provider acts like a "standard craftsman" who creates the same type of component
+// every time without needing special instructions or customization.
 //
 // Returns:
 //   - T: The created dependency instance
@@ -109,16 +129,22 @@ type NoneParamProvider[T any] interface {
 }
 
 // NamedProvider is an interface for providers that can create dependencies based on name and type.
-// It extends NamedGoner to support named component registration and provides a more flexible Provide method
-// that can create dependencies of any type.
+// Think of it as a "master craftsman" with a business card who can create any type of component
+// based on specific requirements. It extends NamedGoner to support named component registration
+// and provides a more flexible Provide method that can create dependencies of any type.
 //
 // The interface requires:
 //   - Embedding the NamedGoner interface to support named component registration
 //   - Implementing Provide() to create dependencies based on tag config and requested type
 //
+// This provider acts like a "versatile craftsman" who can adapt their skills to create
+// different types of components based on the specific type requested and configuration provided.
+//
 // Parameters for Provide:
-//   - tagConf: Configuration string from the struct tag that requested this dependency
-//   - t: The `reflect.Type` of the dependency being requested
+//   - tagConf: Configuration string from the struct tag that requested this dependency,
+//             like a "detailed work order" specifying requirements
+//   - t: The `reflect.Type` of the dependency being requested,
+//        like a "blueprint" showing what type of component to create
 //
 // Returns:
 //   - any: The created dependency instance of the requested type
@@ -131,7 +157,7 @@ type NoneParamProvider[T any] interface {
 //	}
 //
 //	func (p *ConfigProvider) Provide(tagConf string, t reflect.Type) (any, error) {
-//	    // Create and return instance based on t
+//	    // Create and return instance based on the type blueprint
 //	    return &Config{}, nil
 //	}
 type NamedProvider interface {
@@ -140,64 +166,94 @@ type NamedProvider interface {
 }
 
 // StructFieldInjector is an interface for components that can inject dependencies into struct fields.
-// It extends NamedGoner to support named component registration and provides a method to inject dependencies
-// into struct fields based on tag configuration and field information.
+// Think of it as a "specialized installer" who knows how to install specific components into
+// struct fields based on installation instructions. It extends NamedGoner to support named
+// component registration and provides a method to inject dependencies into struct fields
+// based on tag configuration and field information.
 //
 // The interface requires:
 //   - Embedding the NamedGoner interface to support named component registration
 //   - Implementing Inject() to inject dependencies into struct fields
 //
+// This injector acts like a "field specialist" who can precisely install components
+// into specific struct fields based on the field's requirements and configuration.
+//
 // Parameters for Inject:
-//   - tagConf: Configuration string from the struct tag that requested this dependency
-//   - field: The `reflect.StructField` that requires injection
+//   - tagConf: Configuration string from the struct tag that requested this dependency,
+//             like "installation instructions" specifying how to inject
+//   - field: The `reflect.StructField` that requires injection,
+//           like the "installation location" specification
+//   - fieldValue: The actual field value to be modified during injection
+//
+// Returns:
+//   - error: Any error that occurred during injection
 type StructFieldInjector interface {
 	NamedGoner
 	Inject(tagConf string, field reflect.StructField, fieldValue reflect.Value) error
 }
 
 // Daemon represents a long-running service component that can be started and stopped.
+// Think of it as a "background service worker" that runs continuously to provide specific
+// functionality, like a web server, database connection pool, or message queue processor.
+//
+// Lifecycle Management:
+// Daemons are started in order of registration when Application.Serve() or Application.start() is called.
+// When the application receives a termination signal, daemons are stopped in reverse order
+// to ensure proper cleanup and resource management.
+//
+// Error Handling:
+// - If Start() returns an error, the application will panic to prevent inconsistent state
+// - If Stop() returns an error, the application will panic to ensure proper cleanup
 //
 // Example usage:
 // ```go
 //
 //	type MyDaemon struct {
-//	    Flag
+//	    gone.Flag
 //	}
 //
 //	func (d *MyDaemon) Start() error {
-//	    // Initialize and start the daemon
+//	    // Initialize and start the daemon's main functionality
+//	    // Like starting a web server or opening database connections
 //	    return nil
 //	}
 //
 //	func (d *MyDaemon) Stop() error {
-//	    // Clean up and stop the daemon
+//	    // Gracefully shut down the daemon and clean up resources
+//	    // Like closing connections and saving state
 //	    return nil
 //	}
 //
 // ```
-//
-// Daemons are started in order of registration when Application.Serve() or Application.start() is called.
-// The Start() method should initialize and start the daemon's main functionality.
-// If Start() returns an error, the application will panic.
-//
-// When the application receives a termination signal, daemons are stopped in reverse order
-// by calling their Stop() methods. The Stop() method should gracefully shut down the daemon
-// and clean up any resources. If Stop() returns an error, the application will panic.
 type Daemon interface {
 	Start() error
 	Stop() error
 }
 
 // FuncInjector provides methods for injecting dependencies into function parameters.
+// Think of it as an "intelligent assistant" that automatically identifies what parameters
+// a function needs, then finds the corresponding components from the "warehouse" and
+// automatically "feeds" them to the function. It's like ordering takeout where the
+// delivery person automatically brings all the dishes according to your order.
 //
 // The interface requires implementing:
 //   - InjectFuncParameters: Injects dependencies into function parameters
 //   - InjectWrapFunc: Wraps a function with dependency injection
 //
+// Magic Principles:
+//   - Parameter Recognition: Automatically analyzes function signatures to understand required parameter types
+//   - Smart Matching: Finds matching instances from registered components
+//   - Auto Invocation: Calls the target function with found components as parameters
+//
 // Parameters for both methods:
 //   - fn: The function to inject dependencies into
 //   - injectBefore: Optional hook called before standard injection
 //   - injectAfter: Optional hook called after standard injection
+//
+// Typical Applications:
+//   - Controller Methods: Automatic parameter injection for web request handlers
+//   - Utility Functions: Tool function calls requiring multiple dependencies
+//   - Testing Scenarios: Automatic dependency assembly for test functions
 //
 // Example usage:
 //
@@ -229,16 +285,29 @@ type FuncInjector interface {
 }
 
 // StructInjector defines the interface for components that can inject dependencies into struct fields.
-// It provides a single method to perform dependency injection on struct instances that implement the Goner interface.
+// Think of it as an experienced "assembly worker" who can automatically identify which fields
+// in a struct need "component installation", then find suitable components from the "parts warehouse"
+// and precisely "install" them in the specified locations. It's like assembling a computer where
+// the worker automatically installs corresponding hardware based on the motherboard's interfaces.
 //
 // The interface requires implementing:
 //   - InjectStruct: Injects dependencies into struct fields based on gone tags
+//
+// Work Flow:
+//   - Field Scanning: Checks struct fields with specific tags
+//   - Component Matching: Finds corresponding components based on field types and tag information
+//   - Precise Installation: "Installs" found components into corresponding fields
+//
+// Application Scenarios:
+//   - Component Initialization: Automatically assembles dependencies after component creation
+//   - Test Preparation: Automatically injects mock dependencies for test objects
+//   - Dynamic Assembly: Supplements dependencies for existing objects at runtime
 //
 // Example usage:
 // ```go
 //
 //	type MyGoner struct {
-//	    Flag
+//	    gone.Flag
 //	    Service *MyService `gone:"*"`  // Field to be injected
 //	}
 //
@@ -259,7 +328,7 @@ type StructInjector interface {
 	// It scans the struct's fields for `gone` tags and injects the appropriate dependencies.
 	//
 	// Parameters:
-	//   - goner: The struct instance to inject dependencies into. Must implement Goner interface.
+	//   - goner: Should be a struct pointer.
 	//
 	// Returns:
 	//   - error: Any error that occurred during injection
@@ -272,16 +341,29 @@ var (
 )
 
 // LoaderKey is a unique identifier for tracking loaded components in the Gone container.
-// It uses an internal counter to ensure each loaded component gets a unique key.
+// Think of it as a "component registration number" that uses an internal counter to ensure
+// each loaded component gets a unique identifier, like a social security number for components.
 //
 // The LoaderKey is used to:
-// - Track which components have been loaded
-// - Prevent duplicate loading of components
-// - Provide a way to check component load status
+// - Track which components have been loaded (like a "registration database")
+// - Prevent duplicate loading of components (avoid "double registration")
+// - Provide a way to check component load status ("registration verification")
+//
+// This ensures the framework can efficiently manage component lifecycle and prevent conflicts.
 type LoaderKey struct{ id uint64 }
 
 // LoadFunc represents a function that can load components into a Gone container.
-// It takes a Loader interface as parameter to allow loading additional dependencies.
+// Think of it as a "professional moving company" that knows how to properly "pack" and
+// "relocate" specific types of components into the Gone framework. Each LoadFunc knows
+// how to correctly handle the loading process for particular component types.
+//
+// LoadFunc Work Flow:
+//   - Package Components: Prepare business components for loading
+//   - Transport and Load: Load components into the framework through Loader
+//   - Confirm Checklist: Return loading results (success or error)
+//
+// It takes a Loader interface as parameter to allow loading additional dependencies,
+// enabling LoadFuncs to form a tree-like structure for complex component hierarchies.
 //
 // Example usage:
 // ```go
@@ -302,10 +384,26 @@ type LoadFunc = func(Loader) error
 type MustLoadFunc = func(Loader)
 
 // Loader defines the interface for loading components into the Gone container.
-// It provides methods to load new components and check if components are already loaded.
+// Think of it as a company's "HR onboarding specialist" responsible for handling
+// "onboarding procedures" for new components. It assigns each new component a "employee ID",
+// establishes their "personnel file", and officially includes them in the Gone framework's
+// "employee roster".
+//
+// Onboarding Process:
+//   - Identity Verification: Confirms component implements Goner interface (holds "ID card")
+//   - Assign ID: Allocates unique identifier for the component
+//   - Establish Records: Records component type, dependencies, and other information
+//   - Archive Management: Stores component information in the framework's management system
+//
+// Usage Scenarios:
+//   - Application Startup: Batch loading of core application components
+//   - Plugin Loading: Dynamic loading of plugin components
+//   - Test Environment: Loading specific mock components for testing
 //
 // The interface requires implementing:
 //   - Load: Loads a component into the container with optional configuration
+//   - MustLoad: Loads a component and panics on error (for critical components)
+//   - MustLoadX: Flexible loading that handles both components and LoadFuncs
 //   - Loaded: Checks if a component is already loaded
 type Loader interface {
 	// Load adds a component to the Gone container with optional configuration.
@@ -342,12 +440,20 @@ type Loader interface {
 }
 
 // GonerKeeper interface defines methods for retrieving components from the Gone container.
-// It provides dynamic access to components at runtime, allowing components to be looked up
-// by either name or type.
+// Think of it as a super-intelligent "archive manager" who knows the "home address" of every
+// component in the system. Whether you want to find someone by "name" or by "profession" (type),
+// it can quickly locate them. It provides dynamic access to components at runtime, allowing
+// components to be looked up by either name or type.
 //
 // The interface requires implementing:
 //   - GetGonerByName: Retrieves a component by its registered name
 //   - GetGonerByType: Retrieves a component by its type
+//   - GetGonerByPattern: Retrieves components matching a pattern
+//
+// Practical Scenarios:
+//   - Dynamic Lookup: Find specific components at runtime as needed
+//   - Precise Location: Quickly locate target components by name or type
+//   - Pattern Matching: Use wildcard patterns to batch retrieve components
 //
 // Example usage:
 // ```go
@@ -358,12 +464,12 @@ type Loader interface {
 //	}
 //
 //	func (m *MyComponent) Init() error {
-//	    // Get component by name
+//	    // Get component by name - like looking up someone's "business card"
 //	    if svc := m.keeper.GetGonerByName("service"); svc != nil {
 //	        // Use the service
 //	    }
 //
-//	    // Get component by type
+//	    // Get component by type - like finding someone by "profession"
 //	    if logger := m.keeper.GetGonerByType(reflect.TypeOf(&Logger{})); logger != nil {
 //	        // Use the logger
 //	    }
@@ -373,27 +479,39 @@ type Loader interface {
 // ```
 type GonerKeeper interface {
 	// GetGonerByName retrieves a component by its name.
-	// The name should match either the component's explicit name set via gone.Name() option
-	// or the name returned by its GonerName() method if it implements NamedGoner.
+	// Like looking up someone's "business card" in a directory, this method finds components
+	// by their registered name. The name should match either the component's explicit name
+	// set via gone.Name() option or the name returned by its GonerName() method if it implements NamedGoner.
 	//
 	// Parameters:
-	//   - name: The name of the component to retrieve
+	//   - name: The name of the component to retrieve (the "business card" identifier)
 	//
 	// Returns:
 	//   - any: The component instance if found, nil otherwise
 	GetGonerByName(name string) any
 
 	// GetGonerByType retrieves a component by its type.
-	// The type should match either the exact type of the component or
-	// an interface type that the component implements.
+	// Like finding someone by their "profession" in a company directory, this method
+	// locates components by their type. The type should match either the exact type
+	// of the component or an interface type that the component implements.
 	//
 	// Parameters:
-	//   - t: The reflect.Type of the component to retrieve
+	//   - t: The reflect.Type of the component to retrieve (the "profession" specification)
 	//
 	// Returns:
 	//   - any: The component instance if found, nil otherwise
 	GetGonerByType(t reflect.Type) any
 
+	// GetGonerByPattern retrieves components matching a pattern.
+	// Like searching for "all engineers whose names start with 'John'", this method
+	// finds multiple components that match both a type and a name pattern.
+	//
+	// Parameters:
+	//   - t: The reflect.Type of components to search for
+	//   - pattern: The name pattern to match (supports wildcards like * and ?)
+	//
+	// Returns:
+	//   - []any: Array of component instances that match the criteria
 	GetGonerByPattern(t reflect.Type, pattern string) []any
 }
 

--- a/stage_interface.go
+++ b/stage_interface.go
@@ -100,19 +100,101 @@ type BeforeInitiatorNoError interface {
 	BeforeInit()
 }
 
+// BeforeStarter interface defines components that need to perform actions before the application starts.
+// Components implementing this interface will have their BeforeStart() method called during Gone's startup phase,
+// before any daemons are started but after all components have been initialized.
+//
+// The BeforeStart() method should:
+// - Perform any setup needed before daemons start
+// - Initialize resources that daemons depend on
+// - Handle errors internally since no error is returned
+//
+// Example usage:
+//
+//	type MyComponent struct {
+//	    gone.Flag
+//	    logger *Logger `gone:"*"`
+//	}
+//
+//	func (c *MyComponent) BeforeStart() {
+//	    c.logger.Info("Preparing for application start")
+//	    // perform pre-start setup...
+//	}
 type BeforeStarter interface {
 	BeforeStart()
 }
 
+// AfterStarter interface defines components that need to perform actions after the application starts.
+// Components implementing this interface will have their AfterStart() method called during Gone's startup phase,
+// after all daemons have been started successfully.
+//
+// The AfterStart() method should:
+// - Perform any setup that requires all services to be running
+// - Register with external services or health checks
+// - Handle errors internally since no error is returned
+//
+// Example usage:
+//
+//	type MyComponent struct {
+//	    gone.Flag
+//	    healthCheck *HealthCheck `gone:"*"`
+//	}
+//
+//	func (c *MyComponent) AfterStart() {
+//	    c.healthCheck.Register()
+//	    // perform post-start setup...
+//	}
 type AfterStarter interface {
 	AfterStart()
 }
 
-type BeforeStoper interface {
+// BeforeStopper interface defines components that need to perform actions before the application stops.
+// Components implementing this interface will have their BeforeStop() method called during Gone's shutdown phase,
+// before any daemons are stopped but after termination signal is received.
+//
+// The BeforeStop() method should:
+// - Perform cleanup tasks while all services are still running
+// - Save important state or data
+// - Gracefully disconnect from external services
+// - Handle errors internally since no error is returned
+//
+// Example usage:
+//
+//	type MyComponent struct {
+//	    gone.Flag
+//	    cache *Cache `gone:"*"`
+//	}
+//
+//	func (c *MyComponent) BeforeStop() {
+//	    c.cache.Flush()
+//	    // perform pre-stop cleanup...
+//	}
+type BeforeStopper interface {
 	BeforeStop()
 }
 
-type AfterStoper interface {
+// AfterStopper interface defines components that need to perform actions after the application stops.
+// Components implementing this interface will have their AfterStop() method called during Gone's shutdown phase,
+// after all daemons have been stopped successfully.
+//
+// The AfterStop() method should:
+// - Perform final cleanup tasks
+// - Release any remaining resources
+// - Log shutdown completion
+// - Handle errors internally since no error is returned
+//
+// Example usage:
+//
+//	type MyComponent struct {
+//	    gone.Flag
+//	    logger *Logger `gone:"*"`
+//	}
+//
+//	func (c *MyComponent) AfterStop() {
+//	    c.logger.Info("Application shutdown complete")
+//	    // perform final cleanup...
+//	}
+type AfterStopper interface {
 	AfterStop()
 }
 
@@ -151,33 +233,13 @@ type AfterStoper interface {
 //    - AfterStop hooks are executed
 //    - Application terminates
 //
-// Hook Functions:
-// Gone provides several hook functions that components can use to execute code at specific lifecycle points:
-//
-// - BeforeInit/BeforeInitNoError: Called before component initialization
-//   Usage: Implement BeforeInitiator or BeforeInitiatorNoError interface
-//
-// - Init/InitNoError: Called during component initialization
-//   Usage: Implement Initiator or InitiatorNoError interface
-//
-// - BeforeStart: Executed before application startup
-//   Usage: Inject BeforeStart type and register callback functions
-//
-// - AfterStart: Executed after all components have started
-//   Usage: Inject AfterStart type and register callback functions
-//
-// - BeforeStop: Executed before components begin shutting down
-//   Usage: Inject BeforeStop type and register callback functions
-//
-// - AfterStop: Executed after all components have stopped
-//   Usage: Inject AfterStop type and register callback functions
-//
+
 // Hook functions allow components to properly initialize, cleanup, and coordinate
 // with other components during the application lifecycle.
 
 // Process represents a function that performs some operation without taking parameters or returning values.
-// It is commonly used for hook functions in the application lifecycle, such as BeforeStart, AfterStart,
-// BeforeStop and AfterStop hooks.
+// It is commonly used for Hook functions in the application lifecycle, such as BeforeStart, AfterStart,
+// BeforeStop and AfterStop Hook.
 //
 // Example usage:
 // ```go
@@ -198,7 +260,7 @@ type AfterStoper interface {
 // ```
 type Process func()
 
-// BeforeStart is a hook function type that can be injected into Goners to register callbacks
+// BeforeStart is a HookReg function type that can be injected into Goners to register callbacks
 // that will execute before the application starts.
 //
 // Example usage:
@@ -206,7 +268,7 @@ type Process func()
 //
 //	type XGoner struct {
 //	    Flag
-//	    before BeforeStart `gone:"*"` // Inject the BeforeStart hook
+//	    before BeforeStart `gone:"*"` // Inject the BeforeStart HookReg
 //	}
 //
 //	func (x *XGoner) Init() error {
@@ -224,7 +286,7 @@ type Process func()
 // begins its main operations.
 type BeforeStart func(Process)
 
-// AfterStart is a hook function type that can be injected into Goners to register callbacks
+// AfterStart is a HookReg function type that can be injected into Goners to register callbacks
 // that will execute after the application starts.
 //
 // Example usage:
@@ -232,7 +294,7 @@ type BeforeStart func(Process)
 //
 //	type XGoner struct {
 //	    Flag
-//	    after AfterStart `gone:"*"` // Inject the AfterStart hook
+//	    after AfterStart `gone:"*"` // Inject the AfterStart HookReg
 //	}
 //
 //	func (x *XGoner) Init() error {
@@ -249,7 +311,7 @@ type BeforeStart func(Process)
 // This allows components to perform tasks that require all services to be running.
 type AfterStart func(Process)
 
-// BeforeStop is a hook function type that can be injected into Goners to register callbacks
+// BeforeStop is a HookReg function type that can be injected into Goners to register callbacks
 // that will execute before the application stops.
 //
 // Example usage:
@@ -257,7 +319,7 @@ type AfterStart func(Process)
 //
 //	type XGoner struct {
 //	    Flag
-//	    before BeforeStop `gone:"*"` // Inject the BeforeStop hook
+//	    before BeforeStop `gone:"*"` // Inject the BeforeStop HookReg
 //	}
 //
 //	func (x *XGoner) Init() error {
@@ -274,7 +336,7 @@ type AfterStart func(Process)
 // This allows components to perform cleanup tasks while services are still running.
 type BeforeStop func(Process)
 
-// AfterStop is a hook function type that can be injected into Goners to register callbacks
+// AfterStop is a HookReg function type that can be injected into Goners to register callbacks
 // that will execute after the application stops.
 //
 // Example usage:
@@ -282,7 +344,7 @@ type BeforeStop func(Process)
 //
 //	type XGoner struct {
 //	    Flag
-//	    after AfterStop `gone:"*"` // Inject the AfterStop hook
+//	    after AfterStop `gone:"*"` // Inject the AfterStop HookReg
 //	}
 //
 //	func (x *XGoner) Init() error {


### PR DESCRIPTION

Add comprehensive documentation for lifecycle interfaces (BeforeStarter, AfterStarter, BeforeStopper, AfterStopper) with usage examples and best practices Fix typo in interface names (BeforeStoper/AfterStoper to BeforeStopper/AfterStopper) Add SortCoffins call in getByTypeAndPattern to ensure consistent ordering Enhance Application struct documentation with detailed explanations and analogies